### PR TITLE
[LPF-465]: Generate All Data Models Returned by the Service from the Swagger Documentation [Single point of truth]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,40 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.10.0</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>
+                                ${project.basedir}/src/main/resources/swagger.yml
+                            </inputSpec>
+                            <generatorName>spring</generatorName>
+                            <apiPackage>uk.gov.laa.gpfd.api</apiPackage>
+                            <modelPackage>uk.gov.laa.gpfd.model</modelPackage>
+                            <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
+                            <configOptions>
+                                <library>spring-boot</library>
+                                <oas3>false</oas3>
+                                <interfaceOnly>true</interfaceOnly>
+                                <dateLibrary>java8</dateLibrary>
+                                <openApiNullable>false</openApiNullable>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                <useJakartaEe>true</useJakartaEe>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.3</version>
@@ -63,6 +97,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.10</version>
+        </dependency>
         <!--   Springboot dependencies, managed by spring-boot-starter-parent:  -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This PR integrates the `openapi-generator-maven-plugin` version `7.10.0` into the project build lifecycle to automate the generation of API model. The plugin is configured to generate code based on the OAS specification provided in `src/main/swagger.yml`. This ensures synchronization between the API documentation, models, and code, reducing duplication and manual errors. It establishes a single source of truth where request and response models are generated directly from the OAS document. This approach unifies data model definitions, simplifies the mapping of models to service responses.

The plugin uses the spring generator with the spring-boot library and is configured to generate code into the `uk.gov.laa.gpfd.api` and `uk.gov.laa.gpfd.model` packages. It supports only interface generation for API definitions, uses the `java8` date library, and ensures compatibility with Jakarta EE. Generated code is free from timestamps for consistent output. Supporting files like ApiUtil.java are also included for utility purposes.