### PR TITLE
[LPF-465]: Generate All Data Models Returned by the Service from the Swagger Documentation [Single point of truth] - Write more unit tests

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/mapper/ReportsGet200ResponseReportListInnerMapper.java
+++ b/src/main/java/uk/gov/laa/gpfd/mapper/ReportsGet200ResponseReportListInnerMapper.java
@@ -1,0 +1,40 @@
+package uk.gov.laa.gpfd.mapper;
+
+import uk.gov.laa.gpfd.model.MappingTable;
+import uk.gov.laa.gpfd.model.ReportsGet200ResponseReportListInner;
+
+/**
+ * Utility class responsible for mapping a {@link MappingTable} object to a {@link ReportsGet200ResponseReportListInner} object.
+ * <p>
+ * This class provides a method to transform a {@link MappingTable} entity (which holds CSV to SQL mapping details)
+ * into a response object that can be returned in an API response.
+ * </p>
+ */
+public class ReportsGet200ResponseReportListInnerMapper {
+
+    /**
+     * Maps a {@link MappingTable} object to a {@link ReportsGet200ResponseReportListInner} object.
+     * <p>
+     * This method transforms a given {@link MappingTable} entity into a response object used by the service layer
+     * to expose report details such as report name, SQL query, and other metadata to the client.
+     * </p>
+     *
+     * @param mappingTable the {@link MappingTable} object containing the data to be mapped
+     * @return a {@link ReportsGet200ResponseReportListInner} object populated with data from the provided {@link MappingTable}
+     */
+    public static ReportsGet200ResponseReportListInner map(MappingTable mappingTable) {
+        return new ReportsGet200ResponseReportListInner() {{
+            setId(mappingTable.id());
+            setReportName(mappingTable.reportName());
+            setExcelReport(mappingTable.excelReport());
+            setCsvName(mappingTable.csvName());
+            setExcelReport(mappingTable.excelReport());
+            setSqlQuery(mappingTable.sqlQuery());
+            setBaseUrl(mappingTable.baseUrl());
+            reportOwner(mappingTable.reportOwner());
+            reportCreator(mappingTable.reportCreator());
+            description(mappingTable.description());
+            ownerEmail(mappingTable.ownerEmail());
+        }};
+    }
+}

--- a/src/main/java/uk/gov/laa/gpfd/services/MappingTableService.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/MappingTableService.java
@@ -2,62 +2,70 @@ package uk.gov.laa.gpfd.services;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import uk.gov.laa.gpfd.dao.MappingTableDao;
 import uk.gov.laa.gpfd.exception.DatabaseReadException;
 import uk.gov.laa.gpfd.exception.ReportIdNotFoundException;
+import uk.gov.laa.gpfd.mapper.ReportsGet200ResponseReportListInnerMapper;
 import uk.gov.laa.gpfd.model.ReportsGet200ResponseReportListInner;
-import uk.gov.laa.gpfd.model.MappingTable;
 
-import java.util.ArrayList;
 import java.util.List;
 
-
+/**
+ * Service class responsible for interacting with the MappingTable and transforming its data
+ * into a format suitable for API responses.
+ * <p>
+ * This class provides methods to fetch a list of report entries and retrieve details of a specific report
+ * based on the requested report ID. The report data is retrieved from a data source and transformed into
+ * {@link ReportsGet200ResponseReportListInner} objects.
+ * </p>
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MappingTableService {
 
-    private final ModelMapper mapper;
     private final MappingTableDao mappingTableDao;
 
-    public List<ReportsGet200ResponseReportListInner> fetchReportListEntries() throws DatabaseReadException {
-        List<ReportsGet200ResponseReportListInner> reportListEntries = new ArrayList<>();
-
-        //Fetching reportList items from database
-        List<MappingTable> mappingTableObjectList = mappingTableDao.fetchReportList();
-
-        mappingTableObjectList.forEach(obj -> {
-            ReportsGet200ResponseReportListInner reportListResponse = mapper.map(obj, ReportsGet200ResponseReportListInner.class);
-
-            reportListEntries.add(reportListResponse);
-        });
-
-        return reportListEntries;
+    /**
+     * Fetches a list of report entries from the database, maps them into {@link ReportsGet200ResponseReportListInner}
+     * objects, and returns the result.
+     * <p>
+     * This method retrieves all the report entries from the database, transforms them using the
+     * {@link ReportsGet200ResponseReportListInnerMapper#map(MappingTable)} method, and returns a list
+     * of mapped report entries.
+     * </p>
+     *
+     * @return a list of {@link ReportsGet200ResponseReportListInner} objects containing the report data
+     * @throws DatabaseReadException if there is an error fetching data from the database
+     */
+    public List<ReportsGet200ResponseReportListInner> fetchReportListEntries() {
+        return mappingTableDao.fetchReportList().stream()
+                .map(ReportsGet200ResponseReportListInnerMapper::map)
+                .toList();
     }
 
     /**
-     * Create a ReportListResponse with report metadata such as reportname, obtained from the CSV to SQL mapping table
+     * Retrieves the details of a specific report based on the provided report ID.
+     * <p>
+     * This method checks that the report ID is within a valid range (1-999) and attempts to find the report
+     * by its ID. If the report is found, it returns the mapped {@link ReportsGet200ResponseReportListInner}
+     * object. If the report ID is out of range or the report is not found, appropriate exceptions are thrown.
+     * </p>
      *
-     * @param requestedId - the id of the requested report
-     * @return a ReportListResponse from the CSV - SQL mapping table
+     * @param requestedId the ID of the requested report
+     * @return a {@link ReportsGet200ResponseReportListInner} object containing the details of the requested report
+     * @throws IndexOutOfBoundsException if the requested ID is outside the valid range (1-999)
+     * @throws ReportIdNotFoundException if the report with the requested ID is not found
+     * @throws DatabaseReadException if there is an error fetching data from the database
      */
-    public ReportsGet200ResponseReportListInner getDetailsForSpecificReport(int requestedId)  {
-        List<ReportsGet200ResponseReportListInner> reportListResponses;
-        if (requestedId < 1000 && requestedId > 0) {
-            reportListResponses = fetchReportListEntries();
-        } else {
-            throw new IndexOutOfBoundsException("Report ID needs to be a number between 0 and 1000");
-        }
+    public ReportsGet200ResponseReportListInner getDetailsForSpecificReport(int requestedId) {
+        if (requestedId <= 0 || requestedId >= 1000) throw new IndexOutOfBoundsException("Report ID needs to be a number between 0 and 1000");
 
-        int indexInt = requestedId - 1;   // The '-1' accounts for the fact that the array index starts at 0, whereas the database index/id starts at 1
-        log.debug("Checking the reportListResponses for the desired reportListResponse object, the requested report index is: {}", indexInt);
-
-        if (indexInt >= reportListResponses.size()) {
-            throw new ReportIdNotFoundException("Report ID not found with ID: " + requestedId);
-        } else {
-            return reportListResponses.get(indexInt);
-        }
+        return mappingTableDao.fetchReportList().stream()
+                .map(ReportsGet200ResponseReportListInnerMapper::map)
+                .filter(o -> o.getId() == requestedId - 1) // Adjust for 0-based index
+                .findFirst()
+                .orElseThrow(() -> new ReportIdNotFoundException("Report ID not found with ID: " + requestedId));
     }
 }

--- a/src/test/java/uk/gov/laa/gpfd/data/AzureGraphUserTestDataFactory.java
+++ b/src/test/java/uk/gov/laa/gpfd/data/AzureGraphUserTestDataFactory.java
@@ -1,0 +1,88 @@
+package uk.gov.laa.gpfd.data;
+
+import com.microsoft.graph.models.User;
+
+import java.util.Arrays;
+
+/**
+ * A factory class for creating test data instances of {@link com.microsoft.graph.models.User}.
+ * <p>
+ * This class provides methods to create valid and customized {@link User} objects for testing purposes.
+ * </p>
+ */
+public class AzureGraphUserTestDataFactory {
+
+    /**
+     * Creates a valid {@link User} instance populated with realistic default data.
+     *
+     * @return a fully populated {@link User} object with default test data.
+     */
+    public static User aValidUser() {
+        return new User() {{
+            id = "user123";
+            displayName = "Foo Bar";
+            userPrincipalName = "foo.bar@example.com";
+            givenName = "Foo";
+            surname = "Bar";
+            mail = "foo.bar@example.com";
+            city = "London";
+            state = "Active";
+            country = "UK";
+            employeeId = "E12345";
+            companyName = "FooBar";
+            department = "Engineering";
+            businessPhones = Arrays.asList("123-456-7890", "987-654-3210");
+            mobilePhone = "555-123-4567";
+            officeLocation = "Office 101";
+            onPremisesSamAccountName = "foo_bar";
+            onPremisesSecurityIdentifier = "S-1-5-21-1234567890";
+            accountEnabled = true;
+            mailNickname = "foo.bar";
+            jobTitle = "Software Engineer";
+            usageLocation = "GB";
+            otherMails = Arrays.asList("alt.email1@example.com", "alt.email2@example.com");
+            passwordPolicies = "None";
+            passwordProfile = null;
+            preferredLanguage = "en-GB";
+            preferredDataLocation = "GB";
+            onPremisesSyncEnabled = true;
+        }};
+    }
+
+    /**
+     * Creates a valid {@link User} instance with customizable principal name and display name.
+     *
+     * @param userPrincipalName the principal name of the user (e.g., email address or unique identifier).
+     * @param displayName       the display name of the user.
+     * @return a {@link User} object populated with the specified user principal name and display name.
+     */
+    public static User aValidUserWithCustomData(String userPrincipalName, String displayName) {
+        return new User() {{
+            userPrincipalName = userPrincipalName;
+            displayName = displayName;
+            givenName = "Foo";
+            surname = "bar";
+            mail = "foo.bar@example.com";
+            jobTitle = "Software Engineer";
+            city = "London";
+            state = "Active";
+            country = "UK";
+            accountEnabled = true;
+        }};
+    }
+
+    /**
+     * Creates a minimal {@link User} instance with only basic fields populated.
+     *
+     * @return a {@link User} object populated with minimal data for testing.
+     */
+    public static User aValidUserSmallUser() {
+        return new User() {{
+            userPrincipalName = "testPrincipalName";
+            givenName = "testGivenName";
+            surname = "testSurname";
+            preferredName = "testPreferredName";
+            mail = "testMail";
+        }};
+    }
+}

--- a/src/test/java/uk/gov/laa/gpfd/data/MappingTableTestDataFactory.java
+++ b/src/test/java/uk/gov/laa/gpfd/data/MappingTableTestDataFactory.java
@@ -1,0 +1,49 @@
+package uk.gov.laa.gpfd.data;
+
+import uk.gov.laa.gpfd.model.MappingTable;
+
+public class MappingTableTestDataFactory {
+
+    /**
+     * Creates a valid MappingTable record for the first report entry.
+     *
+     * @return a MappingTable record with data for the first report entry.
+     */
+    public static MappingTable aValidInvoiceAnalysisReport() {
+        return new MappingTable(
+                1,
+                "CCMS_invoice_analysis-CIS-to-CCMS-import-analysis-2",
+                "CCMS_invoice_analysis",
+                "CIS-to-CCMS-import-analysis",
+                2,
+                "SELECT * FROM ANY_REPORT.V_CIS_TO_CCMS_INVOICE_SUMMARY",
+                "https://foo.ba.com/:x:/r/sites/Shared%20Documents/General/Monthly%20Accounts/Sharepoint%20base%20reports/General%20CCMS%20Tools/CCMS%20invoice%20analysis.xlsb?d=w7bc78b4b2c94489e899415353a37d234&csf=1&web=1&e=K0h3OD",
+                "Chancey Mctavish",
+                "Sophia Patel",
+                "Summary of invoices in CIS and CCMS by original source IT system",
+                "owneremail@email.com"
+        );
+    }
+
+    /**
+     * Creates a valid MappingTable record for the second report entry.
+     *
+     * @return a MappingTable record with data for the second report entry.
+     */
+    public static MappingTable aValidBankAccountReport() {
+        return new MappingTable(
+                2,
+                "CCMS_and_CIS_Bank_Account_Report_w_Category_Code_(MNTH)-MAIN-12",
+                "CCMS_and_CIS_Bank_Account_Report_w_Category_Code_(MNTH)",
+                "MAIN",
+                12,
+                "SELECT * FROM ANY_REPORT.V_BANK_MONTH",
+                "https://foo.bar.com/sites/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FFinanceSysReference%2FShared%20Documents%2FGeneral%2FMonthly%20Accounts%2F2023%2D06%2FBank%20reporting&viewid=5d6ec327%2D2975%2D4d7c%2Dbd8d%2D6b793c45868b",
+                "Daniel Mctavish",
+                "Brian Limond",
+                "Summary of all payments made by CCMS/CIS and all cash receipts applied to debt in the previous month",
+                "secondowneremail@email.com"
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/laa/gpfd/service/MappingTableServiceTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/service/MappingTableServiceTest.java
@@ -1,0 +1,197 @@
+package uk.gov.laa.gpfd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.laa.gpfd.dao.MappingTableDao;
+import uk.gov.laa.gpfd.data.MappingTableTestDataFactory;
+import uk.gov.laa.gpfd.exception.DatabaseReadException;
+import uk.gov.laa.gpfd.exception.ReportIdNotFoundException;
+import uk.gov.laa.gpfd.mapper.ReportsGet200ResponseReportListInnerMapper;
+import uk.gov.laa.gpfd.model.MappingTable;
+import uk.gov.laa.gpfd.services.MappingTableService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MappingTableServiceTest {
+
+    @Mock
+    private MappingTableDao mappingTableDao;
+
+    @InjectMocks
+    private MappingTableService mappingTableService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void shouldReturnReportListEntriesWhenValidReportsExist() {
+        // Given
+        var mappingTable1 = MappingTableTestDataFactory.aValidBankAccountReport();
+        var mappingTable2 = MappingTableTestDataFactory.aValidInvoiceAnalysisReport();
+        var list = Arrays.asList(mappingTable1, mappingTable2);
+        var expected = list.stream().map(ReportsGet200ResponseReportListInnerMapper::map).toList();
+
+        when(mappingTableDao.fetchReportList()).thenReturn(list);
+
+        // When
+        var result = mappingTableService.fetchReportListEntries();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(expected.size(), result.size());
+        assertEquals(expected, result);
+        verify(mappingTableDao, times(1)).fetchReportList();
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoReportsExist() {
+        // Given
+        when(mappingTableDao.fetchReportList()).thenReturn(Collections.emptyList());
+
+        // When
+        var result = mappingTableService.fetchReportListEntries();
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(mappingTableDao, times(1)).fetchReportList();
+    }
+
+    @Test
+    void shouldReturnSingleReportWhenOnlyOneReportExists() throws DatabaseReadException {
+        // Given
+        var singleReport = MappingTableTestDataFactory.aValidInvoiceAnalysisReport();
+        when(mappingTableDao.fetchReportList()).thenReturn(Collections.singletonList(singleReport));
+        var expected = List.of(ReportsGet200ResponseReportListInnerMapper.map(singleReport));
+
+        // When
+        var result = mappingTableService.fetchReportListEntries();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(expected.size(), result.size());
+        assertEquals(expected, result);
+        verify(mappingTableDao, times(1)).fetchReportList();
+    }
+
+    @Test
+    void shouldHandleSizeLimitExceededAndReturnAllReports() throws DatabaseReadException {
+        // Given
+        var largeList = new ArrayList<MappingTable>();
+        for (int i = 0; i < 1001; i++) {  // Exceed the size limit
+            largeList.add(MappingTableTestDataFactory.aValidInvoiceAnalysisReport());
+        }
+        when(mappingTableDao.fetchReportList()).thenReturn(largeList);
+
+        // When
+        var result = mappingTableService.fetchReportListEntries();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(largeList.size(), result.size());
+        verify(mappingTableDao, times(1)).fetchReportList();
+    }
+
+    @Test
+    void shouldReturnValidReportsAndIgnoreInvalidData() throws DatabaseReadException {
+        // Given
+        var mappingTable1 = MappingTableTestDataFactory.aValidInvoiceAnalysisReport();
+        var mappingTable2 = new MappingTable(999, null, null, null, 0, null, null, null, null, null, null); // Invalid data
+        var list = Arrays.asList(mappingTable1, mappingTable2);
+        when(mappingTableDao.fetchReportList()).thenReturn(list);
+
+        // When
+        var result = mappingTableService.fetchReportListEntries();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());  // Only one valid mapping should be returned
+        verify(mappingTableDao, times(1)).fetchReportList();
+    }
+
+    @Test
+    void shouldThrowIndexOutOfBoundsExceptionWhenRequestedIdIsLessThanZero() {
+        // Given
+        var invalidId = 0;
+
+        // When
+        // Then
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(invalidId));
+    }
+
+    @Test
+    void shouldThrowIndexOutOfBoundsExceptionWhenRequestedIdIsGreaterThan1000() {
+        // Given
+        var invalidId = 1001;
+
+        // When
+        // Then
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(invalidId));
+    }
+
+    @Test
+    void shouldThrowReportIdNotFoundExceptionWhenRequestedReportDoesNotExist() {
+        // Given
+        var requestedId = 2;
+        when(mappingTableDao.fetchReportList()).thenReturn(List.of(MappingTableTestDataFactory.aValidBankAccountReport()));
+
+        // When
+        // Then
+        assertThrows(ReportIdNotFoundException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(requestedId));
+    }
+
+    @Test
+    void shouldThrowReportIdNotFoundExceptionWhenReportListIsEmpty() {
+        // Given
+        var requestedId = 1;
+        when(mappingTableDao.fetchReportList()).thenReturn(Collections.emptyList());
+
+        // When
+        // Then
+        assertThrows(ReportIdNotFoundException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(requestedId));
+    }
+
+    @Test
+    void shouldThrowIndexOutOfBoundsExceptionWhenRequestedIdIsNegative() {
+        // Given
+        var requestedId = -1;
+
+        // When
+        // Then
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(requestedId));
+    }
+
+    @Test
+    void shouldThrowReportIdNotFoundExceptionWhenRequestedIdExceedsAvailableReports() {
+        // Given
+        var requestedId = 100;
+        when(mappingTableDao.fetchReportList()).thenReturn(List.of(MappingTableTestDataFactory.aValidBankAccountReport()));
+
+        // When
+        // Then
+        assertThrows(ReportIdNotFoundException.class,
+                () -> mappingTableService.getDetailsForSpecificReport(requestedId));
+    }
+
+}

--- a/src/test/java/uk/gov/laa/gpfd/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/service/UserServiceTest.java
@@ -2,68 +2,177 @@ package uk.gov.laa.gpfd.service;
 
 import com.microsoft.graph.core.ClientException;
 import com.microsoft.graph.models.User;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import uk.gov.laa.gpfd.bean.UserDetails;
+import uk.gov.laa.gpfd.data.AzureGraphUserTestDataFactory;
 import uk.gov.laa.gpfd.exception.AuthUserNotFoundException;
 import uk.gov.laa.gpfd.exception.UserServiceException;
 import uk.gov.laa.gpfd.graph.AzureGraphClient;
 import uk.gov.laa.gpfd.services.UserService;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
-  @Mock
-  OAuth2AuthorizedClient mockOAuth2Client;
+    @Mock
+    OAuth2AuthorizedClient mockOAuth2Client;
 
-  @Mock
-  AzureGraphClient mockAzureGraphClient;
+    @Mock
+    AzureGraphClient mockAzureGraphClient;
 
-  @InjectMocks
-  UserService userService;
+    @InjectMocks
+    UserService userService;
 
-  @NotNull
-  private static User createGraphUser() {
-    User graphUser = new User();
-    graphUser.userPrincipalName = "testPrincipalName";
-    graphUser.givenName = "testGivenName";
-    graphUser.surname = "testSurname";
-    graphUser.preferredName = "testPreferredName";
-    graphUser.mail = "testMail";
-    return graphUser;
-  }
+    @Test
+    void shouldReturnValidUserWhenGraphReturnsCompleteUserDetails() {
+        var graphUser = AzureGraphUserTestDataFactory.aValidUserSmallUser();
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(graphUser);
 
-  @Test
-  void whenUserIsReturnedFromGraphUserDetailsAreMappedCorrectly() throws Exception {
-    User graphUser = createGraphUser();
+        var result = userService.getUserDetails(mockOAuth2Client);
 
-    when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(graphUser);
+        assertEquals(graphUser.userPrincipalName, result.userPrincipalName());
+        assertEquals(graphUser.givenName, result.givenName());
+        assertEquals(graphUser.surname, result.surname());
+        assertEquals(graphUser.preferredName, result.preferredName());
+        assertEquals(graphUser.mail, result.email());
+    }
 
-    UserDetails result = userService.getUserDetails(mockOAuth2Client);
+    @Test
+    void shouldThrowAuthUserNotFoundExceptionWhenGraphReturnsNullUser() {
+        assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
+    }
 
-    assertEquals(graphUser.userPrincipalName, result.userPrincipalName());
-    assertEquals(graphUser.givenName, result.givenName());
-    assertEquals(graphUser.surname, result.surname());
-    assertEquals(graphUser.preferredName, result.preferredName());
-    assertEquals(graphUser.mail, result.email());
-  }
+    @Test
+    void shouldThrowUserServiceExceptionWhenClientExceptionOccurs() {
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenThrow(new ClientException("client error", null));
 
-  @Test
-  void whenNullGraphUserIsReturnedUserServiceExceptionIsThrown() {
-    assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
-  }
+        // Then
+        assertThrows(UserServiceException.class, () -> userService.getUserDetails(mockOAuth2Client));
+    }
 
-  @Test
-  void whenGraphExceptionThenUserServiceExceptionIsThrown() {
-    when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenThrow(new ClientException("client error", null));
+    @Test
+    void shouldReturnErrorMessageWhenNoDetailsAreReturnedFromGraph() {
+        // Given
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(null);
 
-    assertThrows(UserServiceException.class, () -> userService.getUserDetails(mockOAuth2Client));
-  }
+        // When
+        var exception = assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
+
+        // Then
+        assertEquals("No user details returned from Graph", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowAuthUserNotFoundExceptionWhenGraphUserDataIsIncomplete() {
+        // Given
+        var incompleteUser = new User(); // Missing userPrincipalName and email
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(incompleteUser);
+
+        // When & Assert
+        var exception = assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
+
+        // Then
+        assertEquals("No user details returned from Graph", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowUserServiceExceptionWhenGraphClientThrowsError() {
+        // Given
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenThrow(new ClientException("Error", null));
+
+        // When & Assert
+        var exception = assertThrows(UserServiceException.class, () -> userService.getUserDetails(mockOAuth2Client));
+
+        // Then
+        assertEquals("Failed to retrieve Graph User", exception.getMessage());
+        assertInstanceOf(ClientException.class, exception.getCause());
+    }
+
+    @Test
+    void shouldThrowAuthUserNotFoundExceptionWhenOAuth2ClientIsNull() {
+        // When
+        // Then
+        assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(null));
+    }
+
+    @Test
+    void shouldThrowAuthUserNotFoundExceptionWhenUserPrincipalNameIsEmpty() {
+        // Given
+        var invalidUser = new User();
+        invalidUser.userPrincipalName = "";
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(invalidUser);
+
+        // When
+        var exception = assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
+
+        // Then
+        assertEquals("No user details returned from Graph", exception.getMessage());
+    }
+
+    @Test
+    void shouldMapOtherFieldsWhenUserHasNoGivenName() {
+        // Given
+        var partialUser = AzureGraphUserTestDataFactory.aValidUserSmallUser();
+        partialUser.givenName = null;
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(partialUser);
+
+        // When
+        var result = userService.getUserDetails(mockOAuth2Client);
+
+        // Then
+        assertNull(result.givenName());
+        assertEquals(partialUser.userPrincipalName, result.userPrincipalName());
+        assertEquals(partialUser.surname, result.surname());
+    }
+
+    @Test
+    void shouldMapOtherFieldsWhenUserHasNoSurname() {
+        // Given
+        var partialUser = AzureGraphUserTestDataFactory.aValidUserSmallUser();
+        partialUser.surname = null;
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(partialUser);
+
+        // When
+        var result = userService.getUserDetails(mockOAuth2Client);
+
+        // Then
+        assertNull(result.surname());
+        assertEquals(partialUser.userPrincipalName, result.userPrincipalName());
+        assertEquals(partialUser.givenName, result.givenName());
+    }
+
+    @Test
+    void shouldThrowAuthUserNotFoundExceptionWhenUserPropertiesAreMissing() {
+        // Given
+        var incompleteUser = new User(); // Completely empty user object
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(incompleteUser);
+
+        // When
+        var exception = assertThrows(AuthUserNotFoundException.class, () -> userService.getUserDetails(mockOAuth2Client));
+
+        // Then
+        assertEquals("No user details returned from Graph", exception.getMessage());
+    }
+
+    @Test
+    void shouldUsePreferredNameWhenGivenNameIsNull() {
+        // Given
+        var userWithNullGivenName = AzureGraphUserTestDataFactory.aValidUser();
+        userWithNullGivenName.givenName = null;
+        when(mockAzureGraphClient.getGraphUserDetails(mockOAuth2Client)).thenReturn(userWithNullGivenName);
+
+        // When
+        var result = userService.getUserDetails(mockOAuth2Client);
+
+        // Then
+        assertEquals(userWithNullGivenName.preferredName, result.preferredName());
+    }
 }


### PR DESCRIPTION
This PR introduces multiple updates aimed at improving the testing and functionality of the `MappingTableService` and related components. These changes include the creation of test data factories, improvements to the service logic, and the addition of new test cases to ensure comprehensive test coverage.

In MappingTableService.java, the logic of the service was refined, particularly for the methods `fetchReportListEntries` and `getDetailsForSpecificReport`. The `fetchReportListEntries` method was streamlined to fetch and map report entries more efficiently, while the `getDetailsForSpecificReport` method was enhanced with better validation for report IDs, including checks for valid ranges and appropriate error handling. The class utilizes a MappingTableDao to fetch the report data and a mapper to transform the data into the response format expected by the API.
