### PR TITLE
[LPF-558]: Fix ECR deployment in UAT

### DIFF
--- a/.github/workflows/deploy_to_uat.yml
+++ b/.github/workflows/deploy_to_uat.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: './.github/login-to-aws'
         env:
-          ROLE: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ROLE: ${{ secrets.UAT_ECR_ROLE_TO_ASSUME }}
           AWS_REGION: ${{ vars.ECR_REGION }}
 
       - name: Login to container repository
@@ -32,7 +32,7 @@ jobs:
 
       - uses: './.github/build-push-docker-image'
         env:
-          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          REPOSITORY: ${{ vars.UAT_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
@@ -40,7 +40,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ github.sha }} # Tags ECR image with commit sha
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          REPOSITORY: ${{ vars.UAT_ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE_UAT }}
         run: |
           cat deployments/uat/deployment.tpl | envsubst > deployments/uat/deployment.yml


### PR DESCRIPTION
This PR addresses deployment issues observed in the recent ECR deployment within the UAT environment. 
Changes:
- Replaced the use of the production ECR repository `(vars.ECR_REPOSITORY)` with the dedicated UAT ECR repository `(vars.UAT_ECR_REPOSITORY)` in all relevant configurations.
- Replaced the production ECR IAM role `(secrets.ECR_ROLE_TO_ASSUME)` with the dedicated UAT ECR IAM role `(secrets.UAT_ECR_ROLE_TO_ASSUME)`