### PR TITLE
Update the GPFD configuration to point to the new UAT env

### DIFF
--- a/deployments/uat/deployment.tpl
+++ b/deployments/uat/deployment.tpl
@@ -38,12 +38,12 @@ spec:
                 secretKeyRef:
                   name: gpfd-uat-secret-01
                   key: tenant-id-uat
-            - name: MOJFIN_DEV_READ_USERNAME
+            - name: MOJFIN_UAT_READ_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: gpfd-uat-secret-01
                   key: mojfin-dev-read-username
-            - name: MOJFIN_DEV_READ_PASSWORD
+            - name: MOJFIN_UAT_READ_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: gpfd-uat-secret-01
@@ -53,12 +53,12 @@ spec:
                 secretKeyRef:
                   name: gpfd-uat-secret-01
                   key: ssl-dev-key-store-password
-            - name: MOJFIN_DEV_WRITE_USERNAME
+            - name: MOJFIN_UAT_WRITE_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: gpfd-uat-secret-01
                   key: mojfin-dev-write-username
-            - name: MOJFIN_DEV_WRITE_PASSWORD
+            - name: MOJFIN_UAT_WRITE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: gpfd-uat-secret-01

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -1,17 +1,16 @@
 gpfd:
   url: https://laa-get-payments-finance-data-uat.apps.live.cloud-platform.service.justice.gov.uk
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-uat
-  # DEV MOJFIN database config - needs to change to UAT when that exists:
   datasource:
     read-only:
-      url: jdbc:oracle:thin:@RDS.MOJFIN.LAA-DEVELOPMENT.MODERNISATION-PLATFORM.SERVICE.JUSTICE.GOV.UK:1521/MOJFIN
-      username: ${MOJFIN_DEV_READ_USERNAME}
-      password: ${MOJFIN_DEV_READ_PASSWORD}
+      url: jdbc:oracle:thin:@rds.mojfin.laa-preproduction.modernisation-platform.service.justice.gov.uk:1521/MOJFIN
+      username: ${MOJFIN_UAT_READ_USERNAME}
+      password: ${MOJFIN_UAT_READ_PASSWORD}
       driver-class-name: oracle.jdbc.OracleDriver
     write:
-      url: jdbc:oracle:thin:@RDS.MOJFIN.LAA-DEVELOPMENT.MODERNISATION-PLATFORM.SERVICE.JUSTICE.GOV.UK:1521/MOJFIN
-      username: ${MOJFIN_DEV_WRITE_USERNAME}
-      password: ${MOJFIN_DEV_WRITE_PASSWORD}
+      url: jdbc:oracle:thin:@rds.mojfin.laa-preproduction.modernisation-platform.service.justice.gov.uk:1521/MOJFIN
+      username: ${MOJFIN_UAT_WRITE_USERNAME}
+      password: ${MOJFIN_UAT_WRITE_PASSWORD}
       driver-class-name: oracle.jdbc.OracleDriver
 
 spring:


### PR DESCRIPTION
This pull request updates the GPFD configuration to point to the UAT (User Acceptance Testing) environment.

**Changes:**

The datasource URL for both read-only and write connections has been updated to point to the UAT environment:
From: j`dbc:oracle:thin:@RDS.MOJFIN.LAA-DEVELOPMENT.MODERNISATION-PLATFORM.SERVICE.JUSTICE.GOV.UK:1521/MOJFIN`
To: `jdbc:oracle:thin:@rds.mojfin.laa-preproduction.modernisation-platform.service.justice.gov.uk:1521/MOJFIN`