### PR TITLE
[LPF-546]: Add production server to swagger

### DIFF
--- a/src/main/resources/static/swagger.yml
+++ b/src/main/resources/static/swagger.yml
@@ -12,6 +12,16 @@ info:
   contact:
     name: Ministry of Justice
 
+
+servers:
+  - url: https://laa-get-payments-finance-data.apps.live.cloud-platform.service.justice.gov.uk/
+    description: Production Environment
+  - url: https://laa-get-payments-finance-data-uat.apps.live.cloud-platform.service.justice.gov.uk/
+    description: UAT Test Environment
+  - url: https://laa-get-payments-finance-data-dev.apps.live.cloud-platform.service.justice.gov.uk/
+    description: Development Environment
+
+
 components:
   links:
     ReportDetailsLink:


### PR DESCRIPTION
This pull request introduces dynamic configuration for production and staging server details within the Swagger documentation.

Currently, the server URLs are hardcoded within the Swagger file. This update implements a mechanism to populate these values based on the environment (production or staging) during deployment or build processes