### PR TITLE
[LPF 556] Using ingress CA set up

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - LPF-556-ingress-ca
 
 jobs:
 
@@ -61,4 +60,3 @@ jobs:
           kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
           kubectl config use-context ${KUBE_CLUSTER}
           kubectl -n ${KUBE_NAMESPACE} apply -f deployments/development/
-    

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - LPF-556-ingress-ca
 
 jobs:
 

--- a/deployments/development/deployment.tpl
+++ b/deployments/development/deployment.tpl
@@ -63,4 +63,5 @@ spec:
                 secretKeyRef:
                   name: gpfd-test-secret-01
                   key: mojfin-dev-write-password
-
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/deployments/development/deployment.tpl
+++ b/deployments/development/deployment.tpl
@@ -19,7 +19,7 @@ spec:
         - name: gpfd-api-container-dev
           image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
           ports:
-            - containerPort: 8443
+            - containerPort: 8080
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"

--- a/deployments/development/deployment.tpl
+++ b/deployments/development/deployment.tpl
@@ -69,3 +69,5 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault

--- a/deployments/development/deployment.tpl
+++ b/deployments/development/deployment.tpl
@@ -64,4 +64,7 @@ spec:
                   name: gpfd-test-secret-01
                   key: mojfin-dev-write-password
           securityContext:
+            capabilities:
+              drop:
+              - ALL
             allowPrivilegeEscalation: false

--- a/deployments/development/deployment.tpl
+++ b/deployments/development/deployment.tpl
@@ -67,4 +67,5 @@ spec:
             capabilities:
               drop:
               - ALL
+            runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/deployments/development/ingress.tpl
+++ b/deployments/development/ingress.tpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: gpfd-dev-ingress-${NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/backend-protocol: https
+    nginx.ingress.kubernetes.io/backend-protocol: http
     nginx.ingress.kubernetes.io/affinity: "cookie"
 spec:
   ingressClassName: default
@@ -25,7 +25,7 @@ spec:
               service:
                 name: gpfd-dev-service
                 port:
-                  number: 8443
+                  number: 8080
     - host: 'dev.get-legal-aid-data.service.justice.gov.uk'
       http:
         paths:
@@ -35,5 +35,5 @@ spec:
             service:
               name: gpfd-dev-service
               port:
-                number: 8443
+                number: 8080
 

--- a/deployments/development/ingress.tpl
+++ b/deployments/development/ingress.tpl
@@ -12,12 +12,25 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts:
+      - 'dev.get-legal-aid-data.service.justice.gov.uk'
+      secretName: tls-certificate
   rules:
     - host: ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
       http:
         paths:
           - path: /
             pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gpfd-dev-service
+                port:
+                  number: 8443
+    - host: 'dev.get-legal-aid-data.service.justice.gov.uk'
+      http:
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
             backend:
               service:
                 name: gpfd-dev-service

--- a/deployments/development/ingress.tpl
+++ b/deployments/development/ingress.tpl
@@ -31,9 +31,9 @@ spec:
         paths:
         - path: /
           pathType: ImplementationSpecific
-            backend:
-              service:
-                name: gpfd-dev-service
-                port:
-                  number: 8443
+          backend:
+            service:
+              name: gpfd-dev-service
+              port:
+                number: 8443
 

--- a/deployments/development/service-monitor.tpl
+++ b/deployments/development/service-monitor.tpl
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app: gpfd-dev-service # this needs to match the label in the service under metadata:labels:app
   endpoints:
-    - port: https # this is the port name you grabbed from your running service
+    - port: http # this is the port name you grabbed from your running service
       interval: 15s
       path: /actuator/prometheus # this is the endpoint exposed by springboot app

--- a/deployments/development/service.tpl
+++ b/deployments/development/service.tpl
@@ -8,7 +8,7 @@ spec:
   selector:
     app: gpfd-dev
   ports:
-    - name: https
-      port: 8443
-      targetPort: 8443
+    - name: http
+      port: 8080
+      targetPort: 8080
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -33,3 +33,13 @@ spring:
           graph:
             scopes:
               - https://graph.microsoft.com/User.Read
+
+#SSL configuration for the dev and uat environment #todo - switch to using a platform handled cert, as detailed in this task: LPF-415
+server:
+  port: 8443
+  forward-headers-strategy: native # not sure if needed
+  shutdown: graceful
+  servlet:
+    session:
+      cookie:
+        secure: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,7 +36,7 @@ spring:
 
 #SSL configuration for the dev and uat environment #todo - switch to using a platform handled cert, as detailed in this task: LPF-415
 server:
-  port: 8443
+  port: 8080
   forward-headers-strategy: native # not sure if needed
   shutdown: graceful
   servlet:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -33,21 +33,3 @@ spring:
           graph:
             scopes:
               - https://graph.microsoft.com/User.Read
-
-#SSL configuration for the dev and uat environment #todo - switch to using a platform handled cert, as detailed in this task: LPF-415
-server:
-  port: 8443
-  forward-headers-strategy: native # not sure if needed
-  shutdown: graceful
-  servlet:
-    session:
-      cookie:
-        secure: true
-  ssl:
-    key-store: classpath:gpfd-ssl-keystore.p12
-    key-store-password: ${SSL-DEV-KEY-STORE-PASSWORD}
-    key-store-type: PKCS12
-    key-alias: gpfd-dev-ssl-key
-    key-password: ${SSL-DEV-KEY-STORE-PASSWORD}
-
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: TRACE
+    root: INFO
     org:
       springframework:
         security: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: INFO
+    root: TRACE
     org:
       springframework:
         security: INFO


### PR DESCRIPTION
In this PR we are using TLS certificates created by cloud platform with the ingress and removing the SSL connection created by the app. 
We are replacing the back end protocol HTTPS port 8443 to HTTP 8080 in those files 

We can access the reports with HTTPS provided by Cloud Platform:
![image](https://github.com/user-attachments/assets/ca80996a-2028-4ee5-afb3-5173b0468d4c)

We can also use the new domain names as well:
![image](https://github.com/user-attachments/assets/3550d8a0-bceb-4c82-ad65-c71e9bc87c89)
