### PR TITLE
[LPF-559] First prometheus rules

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -55,6 +55,7 @@ jobs:
           cat deployments/development/service.tpl | envsubst > deployments/development/service.yml
           cat deployments/development/service-monitor.tpl | envsubst > deployments/development/service-monitor.yml
           cat deployments/development/network-policy.tpl | envsubst > deployments/development/network-policy.yml
+          cat deployments/development/prometheus-rules.tpl | envsubst > deployments/development/prometheus-rules.yml
 
       - name: Authenticate with Cloud Platform and Deploy
         env:

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-
+      - LPF-559-first-prometheus-rules
 jobs:
 
   build-and-deploy-to-dev:

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-      - LPF-559-first-prometheus-rules
+
 jobs:
 
   build-and-deploy-to-dev:

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -49,6 +49,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE_DEV }}
+          ALERT_SEVERITY: laa-get-legal-aid-data-dev
         run: |
           cat deployments/development/deployment.tpl | envsubst > deployments/development/deployment.yml
           cat deployments/development/ingress.tpl | envsubst > deployments/development/ingress.yml

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -204,3 +204,19 @@ spec:
         for: 1h
         labels:
           severity: ${ALERT_SEVERITY}
+      - alert: 5xxErrorResponses
+        annotations:
+          message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 5xx responses.
+          summary: 5xx server errors.
+        expr: avg by (ingress, exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}",status=~"5.*"}[1m]) > 0)
+        for: 1m
+        labels:
+          severity: ${ALERT_SEVERITY}
+      - alert: 4xxErrorResponses
+        annotations:
+          message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 4xx responses.
+          summary: 4xx client errors.
+        expr: avg by (ingress, exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}",status=~"4.*"}[1m]) > 0)
+        for: 1m
+        labels:
+          severity: ${ALERT_SEVERITY}

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -106,6 +106,6 @@ spec:
           message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 4xx responses.
           summary: 4xx client errors.
         expr: avg by (ingress, exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}",status=~"4.*"}[1m]) > 0)
-        for: 1m
+        for: 0m
         labels:
           severity: ${ALERT_SEVERITY}

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -18,8 +18,7 @@ spec:
           severity: ${ALERT_SEVERITY}
         annotations:
           message: |
-            {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
-            {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
+            {{ $labels.user_arn }} has updated secrets.
           runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/LPF/pages/5297832119/Runbooks
     - name: kubernetes-rules
       rules:
@@ -106,6 +105,6 @@ spec:
           message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 4xx responses.
           summary: 4xx client errors.
         expr: avg by (ingress, exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}",status=~"4.*"}[1m]) > 0)
-        for: 0m
+        for: 1m
         labels:
           severity: ${ALERT_SEVERITY}

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -15,7 +15,7 @@ spec:
         expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:live-laa-get-payments-finance-data-dev-d4def64b8869d886-jJRZ1c"} > 0
         for: 1m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
         annotations:
           message: |
             {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
@@ -37,7 +37,7 @@ spec:
           > 90
         for: 15m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubePodCrashLooping
         annotations:
           message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
@@ -50,7 +50,7 @@ spec:
           * 60 * 5 > 0
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubePodNotReady
         annotations:
           message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
@@ -64,7 +64,7 @@ spec:
           > 0
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeDeploymentGenerationMismatch
         annotations:
           message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
@@ -79,7 +79,7 @@ spec:
           kube_deployment_metadata_generation{job="kube-state-metrics"}
         for: 15m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeDeploymentReplicasMismatch
         annotations:
           message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
@@ -93,7 +93,7 @@ spec:
           != kube_deployment_status_replicas_available{job="kube-state-metrics"}
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeStatefulSetReplicasMismatch
         annotations:
           message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
@@ -108,7 +108,7 @@ spec:
           kube_statefulset_status_replicas{job="kube-state-metrics"}
         for: 15m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeStatefulSetGenerationMismatch
         annotations:
           message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
@@ -149,7 +149,7 @@ spec:
           )
         for: 15m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
         annotations:
           message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
             }} are running where they are not supposed to run.'
@@ -162,7 +162,7 @@ spec:
           > 0
         for: 10m
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeCronJobRunning
         annotations:
           message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
@@ -176,7 +176,7 @@ spec:
           > 3600
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeJobCompletion
         annotations:
           message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
@@ -190,7 +190,7 @@ spec:
           > 0
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}
       - alert: KubeJobFailed
         annotations:
           message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
@@ -203,4 +203,4 @@ spec:
           > 0
         for: 1h
         labels:
-          severity: laa-get-legal-aid-data-dev
+          severity: ${ALERT_SEVERITY}

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -3,7 +3,9 @@ kind: PrometheusRule
 metadata:
   namespace: ${NAMESPACE}
   labels:
+    prometheus: prometheus-operator
     role: alert-rules
+    release: prometheus-operator
   name: prometheus-custom-rules-laa-gpfd-api
 spec:
   groups:
@@ -21,31 +23,39 @@ spec:
           runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/LPF/pages/5297832119/Runbooks
     - name: kubernetes-rules
       rules:
+        - alert: KubeQuotaAlmostFull
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaalmostfull
+            summary: Namespace quota is going to be full.
+          expr: |
+            kube_resourcequota{job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+              > 0.9 < 1
+          for: 15m
+          labels:
+            severity: ${ALERT_SEVERITY}
       - alert: KubeQuota-Exceeded
         annotations:
-          message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+          message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
+            }}% of its {{ $labels.resource }} quota.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
         expr: |-
-          100 * kube_resourcequota{job="kube-state-metrics", type="used"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="$${NAMESPACE}"}
           / ignoring(instance, job, type)
-          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+          (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="$${NAMESPACE}"} > 0)
           > 90
         for: 15m
         labels:
           severity: ${ALERT_SEVERITY}
       - alert: KubePodCrashLooping
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+            }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
         expr: |-
-          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          * 60 * 5 > 0
+          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="${NAMESPACE}"}[15m]) * 60 * 5 > 0
         for: 1h
         labels:
           severity: ${ALERT_SEVERITY}
@@ -55,82 +65,30 @@ spec:
             state for longer than an hour.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
         expr: |-
-          sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"})
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown", namespace="${NAMESPACE}"})
           > 0
         for: 1h
         labels:
           severity: ${ALERT_SEVERITY}
       - alert: KubeDeploymentGenerationMismatch
         annotations:
-          message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
+          message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+            }} does not match, this indicates that the Deployment has failed but has
             not been rolled back.
           runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
         expr: |-
-          kube_deployment_status_observed_generation{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          kube_deployment_status_observed_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
           !=
-          kube_deployment_metadata_generation{job="kube-state-metrics"}
+          kube_deployment_metadata_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
         for: 15m
         labels:
           severity: ${ALERT_SEVERITY}
-      - alert: KubeDeploymentReplicasMismatch
+      - alert: "Kubernetes Container OOM Killer"
         annotations:
-          message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
-            matched the expected number of replicas for longer than an hour.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
-        expr: |-
-          kube_deployment_spec_replicas{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          != kube_deployment_status_replicas_available{job="kube-state-metrics"}
-        for: 1h
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubeCronJobRunning
-        annotations:
-          message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-            than 1h to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-        expr: |-
-          time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          > 3600
-        for: 1h
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubeJobCompletion
-        annotations:
-          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-            than one hour to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
-        expr: |-
-          kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          > 0
-        for: 1h
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubeJobFailed
-        annotations:
-          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
-        expr: |-
-          kube_job_status_failed{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          > 0
-        for: 1h
+          message: The Prometheus server uses a lot of memory and has ocassionally OOMKilled bringing down prometheus. Bump the node group monitoring instance size
+          runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3dc05e588c9115c7aa44c2a9b5e26feff985f965
+        expr: sum_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", namespace="${NAMESPACE}"}[5m]) > 0
+        for: 0m
         labels:
           severity: ${ALERT_SEVERITY}
     - name: application-rules

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -6,7 +6,7 @@ metadata:
     prometheus: prometheus-operator
     role: alert-rules
     release: prometheus-operator
-  name: prometheus-custom-rules-secretsmanager
+  name: prometheus-custom-rules-laa-gpfd-api
 spec:
   groups:
     - name: secretmanager-rules

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -15,7 +15,7 @@ groups:
       expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
       for: 1m
       labels:
-        severity: <severity>
+        severity: laa-get-legal-aid-data-dev
       annotations:
         message: |
           {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
@@ -38,7 +38,7 @@ groups:
         > 90
       for: 15m
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
@@ -51,7 +51,7 @@ groups:
         * 60 * 5 > 0
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubePodNotReady
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
@@ -65,7 +65,7 @@ groups:
         > 0
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
@@ -80,7 +80,7 @@ groups:
         kube_deployment_metadata_generation{job="kube-state-metrics"}
       for: 15m
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeDeploymentReplicasMismatch
       annotations:
         message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
@@ -94,7 +94,7 @@ groups:
         != kube_deployment_status_replicas_available{job="kube-state-metrics"}
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
@@ -109,7 +109,7 @@ groups:
         kube_statefulset_status_replicas{job="kube-state-metrics"}
       for: 15m
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
@@ -150,7 +150,7 @@ groups:
         )
       for: 15m
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
       annotations:
         message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
           }} are running where they are not supposed to run.'
@@ -163,7 +163,7 @@ groups:
         > 0
       for: 10m
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeCronJobRunning
       annotations:
         message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
@@ -177,7 +177,7 @@ groups:
         > 3600
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeJobCompletion
       annotations:
         message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
@@ -191,7 +191,7 @@ groups:
         > 0
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev
     - alert: KubeJobFailed
       annotations:
         message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
@@ -204,4 +204,4 @@ groups:
         > 0
       for: 1h
       labels:
-        severity: warning
+        severity: laa-get-legal-aid-data-dev

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -12,7 +12,7 @@ spec:
     - name: secretmanager-rules
       rules:
       - alert: SecretsManagerPutSecretValue
-        expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
+        expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:live-laa-get-payments-finance-data-dev-d4def64b8869d886-jJRZ1c"} > 0
         for: 1m
         labels:
           severity: laa-get-legal-aid-data-dev
@@ -20,8 +20,7 @@ spec:
           message: |
             {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
             {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
-          runbook_url: <runbook_url>
-          dashboard_url: <dashboard_url>
+          runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/LPF/pages/5297832119/Runbooks
     - name: kubernetes-rules
       rules:
       - alert: KubeQuota-Exceeded

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -3,9 +3,7 @@ kind: PrometheusRule
 metadata:
   namespace: ${NAMESPACE}
   labels:
-    prometheus: prometheus-operator
     role: alert-rules
-    release: prometheus-operator
   name: prometheus-custom-rules-laa-gpfd-api
 spec:
   groups:

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -94,75 +94,6 @@ spec:
         for: 1h
         labels:
           severity: ${ALERT_SEVERITY}
-      - alert: KubeStatefulSetReplicasMismatch
-        annotations:
-          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
-            not matched the expected number of replicas for longer than 15 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
-        expr: |-
-          kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          !=
-          kube_statefulset_status_replicas{job="kube-state-metrics"}
-        for: 15m
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubeStatefulSetGenerationMismatch
-        annotations:
-          message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
-            not been rolled back.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
-        expr: |-
-          kube_statefulset_status_observed_generation{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          !=
-          kube_statefulset_metadata_generation{job="kube-state-metrics"}
-        for: 15m
-        labels:
-          severity: critical
-      - alert: KubeStatefulSetUpdateNotRolledOut
-        annotations:
-          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
-            has not been rolled out.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
-        expr: |-
-          max without (revision) (
-            kube_statefulset_status_current_revision{job="kube-state-metrics"}
-            * on (namespace)
-            group_left()
-            kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-              unless
-            kube_statefulset_status_update_revision{job="kube-state-metrics"}
-          )
-            *
-          (
-            kube_statefulset_replicas{job="kube-state-metrics"}
-            * on (namespace)
-            group_left()
-            kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-            !=
-            kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
-          )
-        for: 15m
-        labels:
-          severity: ${ALERT_SEVERITY}
-        annotations:
-          message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-            }} are running where they are not supposed to run.'
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
-        expr: |-
-          kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
-          * on (namespace)
-          group_left()
-          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-          > 0
-        for: 10m
-        labels:
-          severity: ${ALERT_SEVERITY}
       - alert: KubeCronJobRunning
         annotations:
           message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
@@ -204,6 +135,8 @@ spec:
         for: 1h
         labels:
           severity: ${ALERT_SEVERITY}
+    - name: application-rules
+      rules:
       - alert: 5xxErrorResponses
         annotations:
           message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 5xx responses.

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -36,61 +36,61 @@ spec:
           for: 15m
           labels:
             severity: ${ALERT_SEVERITY}
-      - alert: KubeQuota-Exceeded
-        annotations:
-          message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
-            }}% of its {{ $labels.resource }} quota.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
-        expr: |-
-          100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="$${NAMESPACE}"}
-          / ignoring(instance, job, type)
-          (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="$${NAMESPACE}"} > 0)
-          > 90
-        for: 15m
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubePodCrashLooping
-        annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-            }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-        expr: |-
-          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="${NAMESPACE}"}[15m]) * 60 * 5 > 0
-        for: 1h
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubePodNotReady
-        annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-            state for longer than an hour.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-        expr: |-
-          sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown", namespace="${NAMESPACE}"})
-          > 0
-        for: 1h
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: KubeDeploymentGenerationMismatch
-        annotations:
-          message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
-            }} does not match, this indicates that the Deployment has failed but has
-            not been rolled back.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
-        expr: |-
-          kube_deployment_status_observed_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
-          !=
-          kube_deployment_metadata_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
-        for: 15m
-        labels:
-          severity: ${ALERT_SEVERITY}
-      - alert: "Kubernetes Container OOM Killer"
-        annotations:
-          message: The Prometheus server uses a lot of memory and has ocassionally OOMKilled bringing down prometheus. Bump the node group monitoring instance size
-          runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3dc05e588c9115c7aa44c2a9b5e26feff985f965
-        expr: sum_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", namespace="${NAMESPACE}"}[5m]) > 0
-        for: 0m
-        labels:
-          severity: ${ALERT_SEVERITY}
+        - alert: KubeQuota-Exceeded
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
+              }}% of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+          expr: |-
+            100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="$${NAMESPACE}"}
+            / ignoring(instance, job, type)
+            (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="$${NAMESPACE}"} > 0)
+            > 90
+          for: 15m
+          labels:
+            severity: ${ALERT_SEVERITY}
+        - alert: KubePodCrashLooping
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+          expr: |-
+            rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="${NAMESPACE}"}[15m]) * 60 * 5 > 0
+          for: 1h
+          labels:
+            severity: ${ALERT_SEVERITY}
+        - alert: KubePodNotReady
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+              state for longer than an hour.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+          expr: |-
+            sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown", namespace="${NAMESPACE}"})
+            > 0
+          for: 1h
+          labels:
+            severity: ${ALERT_SEVERITY}
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but has
+              not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+          expr: |-
+            kube_deployment_status_observed_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
+            !=
+            kube_deployment_metadata_generation{job="kube-state-metrics", namespace="${NAMESPACE}"}
+          for: 15m
+          labels:
+            severity: ${ALERT_SEVERITY}
+        - alert: "Kubernetes Container OOM Killer"
+          annotations:
+            message: The Prometheus server uses a lot of memory and has ocassionally OOMKilled bringing down prometheus. Bump the node group monitoring instance size
+            runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3dc05e588c9115c7aa44c2a9b5e26feff985f965
+          expr: sum_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", namespace="${NAMESPACE}"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: ${ALERT_SEVERITY}
     - name: application-rules
       rules:
       - alert: 5xxErrorResponses

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: ${NAMESPACE}
+  labels:
+    role:
+  name: prometheus-custom-rules-secretsmanager
+spec:
+groups:
+  - name: application-rules
+  rules:
+  - alert: SecretsManagerPutSecretValue
+    expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
+    for: 1m
+    labels:
+      severity: <severity>
+    annotations:
+      message: |
+        {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
+        {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
+      runbook_url: <runbook_url>
+      dashboard_url: <dashboard_url>

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -3,20 +3,205 @@ kind: PrometheusRule
 metadata:
   namespace: ${NAMESPACE}
   labels:
-    role:
+    prometheus: prometheus-operator
+    role: alert-rules
+    release: prometheus-operator
   name: prometheus-custom-rules-secretsmanager
 spec:
 groups:
-  - name: application-rules
-  rules:
-  - alert: SecretsManagerPutSecretValue
-    expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
-    for: 1m
-    labels:
-      severity: <severity>
-    annotations:
-      message: |
-        {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
-        {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
-      runbook_url: <runbook_url>
-      dashboard_url: <dashboard_url>
+  - name: secretmanager-rules
+    rules:
+    - alert: SecretsManagerPutSecretValue
+      expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
+      for: 1m
+      labels:
+        severity: <severity>
+      annotations:
+        message: |
+          {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
+          {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
+        runbook_url: <runbook_url>
+        dashboard_url: <dashboard_url>
+  - name: kubernetes-rules
+    rules:
+    - alert: KubeQuota-Exceeded
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+      expr: |-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        / ignoring(instance, job, type)
+        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+        > 90
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubePodNotReady
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"})
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeDeploymentGenerationMismatch
+      annotations:
+        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+      expr: |-
+        kube_deployment_status_observed_generation{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        !=
+        kube_deployment_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDeploymentReplicasMismatch
+      annotations:
+        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+          matched the expected number of replicas for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetReplicasMismatch
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+          not matched the expected number of replicas for longer than 15 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+      expr: |-
+        kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        !=
+        kube_statefulset_status_replicas{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetGenerationMismatch
+      annotations:
+        message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+      expr: |-
+        kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        !=
+        kube_statefulset_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: critical
+    - alert: KubeStatefulSetUpdateNotRolledOut
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+          has not been rolled out.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+      expr: |-
+        max without (revision) (
+          kube_statefulset_status_current_revision{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+            unless
+          kube_statefulset_status_update_revision{job="kube-state-metrics"}
+        )
+          *
+        (
+          kube_statefulset_replicas{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          !=
+          kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+        )
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+          }} are running where they are not supposed to run.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+      expr: |-
+        kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubeCronJobRunning
+      annotations:
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+          than 1h to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+      expr: |-
+        time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        > 3600
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobCompletion
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+          than one hour to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+      expr: |-
+        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobFailed
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+      expr: |-
+        kube_job_status_failed{job="kube-state-metrics"}
+        * on (namespace)
+        group_left()
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+        > 0
+      for: 1h
+      labels:
+        severity: warning

--- a/deployments/development/prometheus-rules.tpl
+++ b/deployments/development/prometheus-rules.tpl
@@ -8,200 +8,200 @@ metadata:
     release: prometheus-operator
   name: prometheus-custom-rules-secretsmanager
 spec:
-groups:
-  - name: secretmanager-rules
-    rules:
-    - alert: SecretsManagerPutSecretValue
-      expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
-      for: 1m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-      annotations:
-        message: |
-          {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
-          {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
-        runbook_url: <runbook_url>
-        dashboard_url: <dashboard_url>
-  - name: kubernetes-rules
-    rules:
-    - alert: KubeQuota-Exceeded
-      annotations:
-        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
-      expr: |-
-        100 * kube_resourcequota{job="kube-state-metrics", type="used"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        / ignoring(instance, job, type)
-        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-        > 90
-      for: 15m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubePodCrashLooping
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-      expr: |-
-        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        * 60 * 5 > 0
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-          state for longer than an hour.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: |-
-        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"})
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        > 0
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeDeploymentGenerationMismatch
-      annotations:
-        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
-          not been rolled back.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
-      expr: |-
-        kube_deployment_status_observed_generation{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        !=
-        kube_deployment_metadata_generation{job="kube-state-metrics"}
-      for: 15m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeDeploymentReplicasMismatch
-      annotations:
-        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
-          matched the expected number of replicas for longer than an hour.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
-      expr: |-
-        kube_deployment_spec_replicas{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeStatefulSetReplicasMismatch
-      annotations:
-        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
-          not matched the expected number of replicas for longer than 15 minutes.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
-      expr: |-
-        kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        !=
-        kube_statefulset_status_replicas{job="kube-state-metrics"}
-      for: 15m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeStatefulSetGenerationMismatch
-      annotations:
-        message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
-          not been rolled back.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
-      expr: |-
-        kube_statefulset_status_observed_generation{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        !=
-        kube_statefulset_metadata_generation{job="kube-state-metrics"}
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeStatefulSetUpdateNotRolledOut
-      annotations:
-        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
-          has not been rolled out.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
-      expr: |-
-        max without (revision) (
-          kube_statefulset_status_current_revision{job="kube-state-metrics"}
+  groups:
+    - name: secretmanager-rules
+      rules:
+      - alert: SecretsManagerPutSecretValue
+        expr: secretsmanager_put_secret_value_sum{exported_job="secretsmanager", secret_id="arn:aws:secretsmanager:eu-west-2:754256621582:secret:<your-secret-arn>"} > 0
+        for: 1m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+        annotations:
+          message: |
+            {{ $labels.secret_id }} has had {{ $value }} PutSecretValue operations recently.
+            {{ $labels.user_arn }} has had {{ $value }} PutSecretValue operations recently.
+          runbook_url: <runbook_url>
+          dashboard_url: <dashboard_url>
+    - name: kubernetes-rules
+      rules:
+      - alert: KubeQuota-Exceeded
+        annotations:
+          message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+        expr: |-
+          100 * kube_resourcequota{job="kube-state-metrics", type="used"}
           * on (namespace)
           group_left()
           kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-            unless
-          kube_statefulset_status_update_revision{job="kube-state-metrics"}
-        )
-          *
-        (
-          kube_statefulset_replicas{job="kube-state-metrics"}
+          / ignoring(instance, job, type)
+          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+          > 90
+        for: 15m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubePodCrashLooping
+        annotations:
+          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+        expr: |-
+          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          * 60 * 5 > 0
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubePodNotReady
+        annotations:
+          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+            state for longer than an hour.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+        expr: |-
+          sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"})
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          > 0
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeDeploymentGenerationMismatch
+        annotations:
+          message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
+            not been rolled back.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+        expr: |-
+          kube_deployment_status_observed_generation{job="kube-state-metrics"}
           * on (namespace)
           group_left()
           kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
           !=
-          kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
-        )
-      for: 15m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-      annotations:
-        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-          }} are running where they are not supposed to run.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
-      expr: |-
-        kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        > 0
-      for: 10m
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeCronJobRunning
-      annotations:
-        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-          than 1h to complete.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-      expr: |-
-        time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        > 3600
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeJobCompletion
-      annotations:
-        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-          than one hour to complete.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
-      expr: |-
-        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        > 0
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
-    - alert: KubeJobFailed
-      annotations:
-        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
-      expr: |-
-        kube_job_status_failed{job="kube-state-metrics"}
-        * on (namespace)
-        group_left()
-        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
-        > 0
-      for: 1h
-      labels:
-        severity: laa-get-legal-aid-data-dev
+          kube_deployment_metadata_generation{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeDeploymentReplicasMismatch
+        annotations:
+          message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+            matched the expected number of replicas for longer than an hour.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+        expr: |-
+          kube_deployment_spec_replicas{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeStatefulSetReplicasMismatch
+        annotations:
+          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+            not matched the expected number of replicas for longer than 15 minutes.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+        expr: |-
+          kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          !=
+          kube_statefulset_status_replicas{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeStatefulSetGenerationMismatch
+        annotations:
+          message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has
+            not been rolled back.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+        expr: |-
+          kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          !=
+          kube_statefulset_metadata_generation{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStatefulSetUpdateNotRolledOut
+        annotations:
+          message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+            has not been rolled out.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+        expr: |-
+          max without (revision) (
+            kube_statefulset_status_current_revision{job="kube-state-metrics"}
+            * on (namespace)
+            group_left()
+            kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+              unless
+            kube_statefulset_status_update_revision{job="kube-state-metrics"}
+          )
+            *
+          (
+            kube_statefulset_replicas{job="kube-state-metrics"}
+            * on (namespace)
+            group_left()
+            kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+            !=
+            kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+          )
+        for: 15m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+        annotations:
+          message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+            }} are running where they are not supposed to run.'
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+        expr: |-
+          kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          > 0
+        for: 10m
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeCronJobRunning
+        annotations:
+          message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+            than 1h to complete.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+        expr: |-
+          time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          > 3600
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeJobCompletion
+        annotations:
+          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+            than one hour to complete.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+        expr: |-
+          kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          > 0
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev
+      - alert: KubeJobFailed
+        annotations:
+          message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+        expr: |-
+          kube_job_status_failed{job="kube-state-metrics"}
+          * on (namespace)
+          group_left()
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
+          > 0
+        for: 1h
+        labels:
+          severity: laa-get-legal-aid-data-dev

--- a/deployments/development/service-monitor.tpl
+++ b/deployments/development/service-monitor.tpl
@@ -7,6 +7,9 @@ spec:
   selector:
     matchLabels:
       app: gpfd-dev-service # this needs to match the label in the service under metadata:labels:app
+  namespaceSelector:
+    matchNames:
+      - ${NAMESPACE}
   endpoints:
     - port: http # this is the port name you grabbed from your running service
       interval: 15s

--- a/deployments/development/service-monitor.tpl
+++ b/deployments/development/service-monitor.tpl
@@ -13,4 +13,4 @@ spec:
   endpoints:
     - port: http # this is the port name you grabbed from your running service
       interval: 15s
-      path: /actuator/prometheus # this is the endpoint exposed by springboot app
+      path: /actuator/metrics # this is the endpoint exposed by springboot app

--- a/deployments/development/service-monitor.tpl
+++ b/deployments/development/service-monitor.tpl
@@ -13,4 +13,4 @@ spec:
   endpoints:
     - port: http # this is the port name you grabbed from your running service
       interval: 15s
-      path: /actuator/metrics # this is the endpoint exposed by springboot app
+      path: /actuator/prometheus # this is the endpoint exposed by springboot app

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: INFO
+    root: DEBUG
     org:
       springframework:
         security: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,14 +12,16 @@ logging:
         web.client.RestTemplate: INFO
 
 management:
+  metrics:
+    enable:
+      spring:
+        security: false
+    tags:
+      application: gpfd-dev-service
   endpoints:
     web:
       exposure:
         include: health,info,metrics,prometheus
-  endpoint:
-    health:
-      probes:
-        enabled: true  # Enable health probes support for Kubernetes
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,8 +16,6 @@ management:
     enable:
       spring:
         security: false
-    tags:
-      application: gpfd-dev-service
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: TRACE
+    root: INFO
     org:
       springframework:
         security: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: INFO
+    root: TRACE
     org:
       springframework:
         security: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: DEBUG
+    root: INFO
     org:
       springframework:
         security: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,10 +12,6 @@ logging:
         web.client.RestTemplate: INFO
 
 management:
-  metrics:
-    enable:
-      spring:
-        security: false
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true  # Enable health probes support for Kubernetes
 
 springdoc:
   api-docs:


### PR DESCRIPTION
This PR is adding 3 types of rules: 
- default prometheus rules for kubernetes suggested by cloud platform https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/application-alerts.yaml
- secret manager alert if a secret has been updated following cloud platform documentation [https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#setting-up-al[…]s-to-a-secret](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#setting-up-alerts-for-changes-to-a-secret) 
- application rules if our ingress is giving 400s or 500s