### PR TITLE
LPF-567 - commons.io build error resolved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
 
         <!-- Test Dependencies-->
         <dependency>
@@ -268,12 +273,6 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>${bytebudy.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Occasional build error from commons.io not being explicitly declared outside of the test code.