### PR TITLE
[LPF-569]: Test Failures Discrepancy: Terminal vs. IntelliJ Builds - update the log to present tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
         <bytebudy.version>1.15.10</bytebudy.version>
         <mockito-inlin.version>3.11.2</mockito-inlin.version>
+        <maven-surefire-junit5-tree-reporte.version>1.1.0</maven-surefire-junit5-tree-reporte.version>
 
         <spring-cloud-azure-dependencies.version>5.19.0</spring-cloud-azure-dependencies.version>
     </properties>
@@ -80,6 +81,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>${maven-surefire-junit5-tree-reporte.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter  implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode"/>
+                </configuration>
                 <version>3.2.3</version>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR introduces a change that enables the short version of logs during test execution. This will provide better visibility into which tests have been run, making it easier to:

- Debug test failures: Quickly identify the specific tests that failed and their order of execution.
- Monitor test progress: Track the progress of test execution and identify any potential bottlenecks.
- Analyze test results: Gain a better understanding of the overall test suite execution and identify areas for improvement