### PR TITLE
Feature/lpf 569 fix integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>src/test/java</compileSourceRoot>
+                                <compileSourceRoot>src/it/java</compileSourceRoot>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -89,6 +108,12 @@
                     </dependency>
                 </dependencies>
                 <configuration>
+
+                    <includes>
+                        <include>**/*Tests.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
                     <reportFormat>plain</reportFormat>
                     <consoleOutputReporter>
                         <disable>true</disable>

--- a/src/it/java/uk/gov/laa/gpfd/integration/AuthTokenIT.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/AuthTokenIT.java
@@ -1,16 +1,20 @@
 package uk.gov.laa.gpfd.integration;
 
 import com.microsoft.graph.models.User;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -23,23 +27,23 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-@AutoConfigureMockMvc
-@ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yml")
 @SpringBootTest
-class GetCsvByIdIT {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private JdbcTemplate writeJdbcTemplate;
+@AutoConfigureMockMvc
+@ActiveProfiles("testauth")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(locations = "classpath:application-testauth.yml")
+class AuthTokenIT {
 
     @MockitoBean
     AzureGraphClient mockAzureGraphClient;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JdbcTemplate writeJdbcTemplate;
 
-    @BeforeEach
+    @BeforeAll
     void setupDatabase() {
         String gpfdSqlSchema = FileUtils.readResourceToString("gpfd_schema.sql");
         String gpfdSqlData = FileUtils.readResourceToString("gpfd_data.sql");
@@ -52,36 +56,45 @@ class GetCsvByIdIT {
         writeJdbcTemplate.execute(anyReportSqlData);
     }
 
-    @AfterEach
+    @AfterAll
     void resetDatabase() {
         writeJdbcTemplate.update("TRUNCATE TABLE GPFD.REPORT_TRACKING");
-        writeJdbcTemplate.update("DROP SEQUENCE GPFD_TRACKING_TABLE_SEQUENCE");
         writeJdbcTemplate.update("TRUNCATE TABLE GPFD.CSV_TO_SQL_MAPPING_TABLE");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"/reports", "/reports/0d4da9ec-b0b3-4371-af10-f375330d85d3", "/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3"})
+    void shouldRedirectToLoginWithoutAuthToken(String endpoint) throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get(endpoint)
+                .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+
+        Assertions.assertEquals(302, response.getStatus());
+        Assertions.assertTrue(response.getRedirectedUrl().contains("/oauth2/authorization/azure"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/reports", "/reports/0d4da9ec-b0b3-4371-af10-f375330d85d3"})
+    void shouldReturn200WhenLoginAuthTokenProvided(String endpoint) throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get(endpoint)
+                .with(SecurityMockMvcRequestPostProcessors.oauth2Login())
+                .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+
+        Assertions.assertEquals(200, response.getStatus());
+    }
+
     @Test
-    void shouldReturnCsvWithMatchingId() throws Exception {
+    void getCsvWithIdShouldReturn200WhenLoginAuthTokenProvided() throws Exception {
         User user = new User();
         user.userPrincipalName = "Test User";
 
         when(mockAzureGraphClient.getGraphUserDetails(any())).thenReturn(user);
 
         MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3")
+                .with(SecurityMockMvcRequestPostProcessors.oauth2Login())
                 .with(oidcLogin()
                         .idToken(token -> token.subject("mockUser")))
                 .with(oauth2Client("graph"))).andReturn().getResponse();
 
         Assertions.assertEquals(200, response.getStatus());
-        Assertions.assertEquals("attachment; filename=CIS to CCMS payment value Defined.csv", response.getHeader("Content-Disposition"));
-    }
-
-    @Test
-    void shouldReturn404WhenNoReportsFound() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-321")
-                .with(oidcLogin()
-                        .idToken(token -> token.subject("mockUser")))
-                .with(oauth2Client("graph"))).andReturn().getResponse();
-
-        Assertions.assertEquals(404, response.getStatus());
     }
 }

--- a/src/it/java/uk/gov/laa/gpfd/integration/GetCsvByIdIT.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/GetCsvByIdIT.java
@@ -1,19 +1,17 @@
 package uk.gov.laa.gpfd.integration;
 
 import com.microsoft.graph.models.User;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -26,22 +24,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("testauth")
-@TestPropertySource(locations = "classpath:application-testauth.yml")
-@SpringBootTest
-class AuthTokenIT {
+@Import(OAuth2TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(locations = "classpath:application-test.yml")
+class GetCsvByIdIT {
 
-    @MockitoBean
-    AzureGraphClient mockAzureGraphClient;
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private JdbcTemplate writeJdbcTemplate;
 
-    @BeforeEach
+    @MockitoBean
+    private AzureGraphClient mockAzureGraphClient;
+
+    @BeforeAll
     void setupDatabase() {
         String gpfdSqlSchema = FileUtils.readResourceToString("gpfd_schema.sql");
         String gpfdSqlData = FileUtils.readResourceToString("gpfd_data.sql");
@@ -54,45 +55,35 @@ class AuthTokenIT {
         writeJdbcTemplate.execute(anyReportSqlData);
     }
 
-    @AfterEach
+    @AfterAll
     void resetDatabase() {
-        writeJdbcTemplate.update("TRUNCATE TABLE GPFD.REPORT_TRACKING");
-        writeJdbcTemplate.update("TRUNCATE TABLE GPFD.CSV_TO_SQL_MAPPING_TABLE");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/reports", "/reports/0d4da9ec-b0b3-4371-af10-f375330d85d3", "/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3"})
-    void shouldRedirectToLoginWithoutAuthToken(String endpoint) throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get(endpoint)
-                .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
-
-        Assertions.assertEquals(302, response.getStatus());
-        Assertions.assertTrue(response.getRedirectedUrl().contains("/oauth2/authorization/azure"));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/reports", "/reports/0d4da9ec-b0b3-4371-af10-f375330d85d3"})
-    void shouldReturn200WhenLoginAuthTokenProvided(String endpoint) throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get(endpoint)
-                .with(SecurityMockMvcRequestPostProcessors.oauth2Login())
-                .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
-
-        Assertions.assertEquals(200, response.getStatus());
+        writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.REPORT_TRACKING");
+        writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.CSV_TO_SQL_MAPPING_TABLE");
     }
 
     @Test
-    void getCsvWithIdShouldReturn200WhenLoginAuthTokenProvided() throws Exception {
+    void shouldReturnCsvWithMatchingId() throws Exception {
         User user = new User();
         user.userPrincipalName = "Test User";
 
         when(mockAzureGraphClient.getGraphUserDetails(any())).thenReturn(user);
 
         MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3")
-                .with(SecurityMockMvcRequestPostProcessors.oauth2Login())
                 .with(oidcLogin()
                         .idToken(token -> token.subject("mockUser")))
                 .with(oauth2Client("graph"))).andReturn().getResponse();
 
         Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("attachment; filename=CIS to CCMS payment value Defined.csv", response.getHeader("Content-Disposition"));
+    }
+
+    @Test
+    void shouldReturn404WhenNoReportsFound() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-321")
+                .with(oidcLogin()
+                        .idToken(token -> token.subject("mockUser")))
+                .with(oauth2Client("graph"))).andReturn().getResponse();
+
+        Assertions.assertEquals(404, response.getStatus());
     }
 }

--- a/src/it/java/uk/gov/laa/gpfd/integration/GetReportsByIdIT.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/GetReportsByIdIT.java
@@ -1,13 +1,15 @@
 package uk.gov.laa.gpfd.integration;
 
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -18,10 +20,12 @@ import uk.gov.laa.gpfd.utils.FileUtils;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(OAuth2TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(locations = "classpath:application-test.yml")
-@SpringBootTest
 class GetReportsByIdIT {
 
     @Autowired
@@ -30,7 +34,7 @@ class GetReportsByIdIT {
     @Autowired
     private JdbcTemplate writeJdbcTemplate;
 
-    @BeforeEach
+    @BeforeAll
     void setupDatabase() {
         String sqlSchema = FileUtils.readResourceToString("gpfd_schema.sql");
         String sqlData = FileUtils.readResourceToString("gpfd_data.sql");
@@ -39,7 +43,7 @@ class GetReportsByIdIT {
         writeJdbcTemplate.execute(sqlData);
     }
 
-    @AfterEach
+    @AfterAll
     void resetDatabase() {
         writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.REPORT_TRACKING");
         writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.CSV_TO_SQL_MAPPING_TABLE");

--- a/src/it/java/uk/gov/laa/gpfd/integration/GetReportsIT.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/GetReportsIT.java
@@ -2,10 +2,11 @@ package uk.gov.laa.gpfd.integration;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,10 +20,11 @@ import uk.gov.laa.gpfd.utils.FileUtils;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(locations = "classpath:application-test.yml")
-@SpringBootTest
 class GetReportsIT {
 
     @Autowired
@@ -31,7 +33,7 @@ class GetReportsIT {
     @Autowired
     private JdbcTemplate writeJdbcTemplate;
 
-    @BeforeEach
+    @BeforeAll
     void setupDatabase() {
         String sqlSchema = FileUtils.readResourceToString("gpfd_schema.sql");
         String sqlData = FileUtils.readResourceToString("gpfd_data.sql");
@@ -40,7 +42,7 @@ class GetReportsIT {
         writeJdbcTemplate.execute(sqlData);
     }
 
-    @AfterEach
+    @AfterAll
     void resetDatabase() {
         writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.REPORT_TRACKING");
         writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.CSV_TO_SQL_MAPPING_TABLE");

--- a/src/it/java/uk/gov/laa/gpfd/integration/OAuth2TestConfig.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/OAuth2TestConfig.java
@@ -1,0 +1,38 @@
+package uk.gov.laa.gpfd.integration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestTemplate;
+
+@TestConfiguration
+public class OAuth2TestConfig {
+
+    @MockitoBean
+    private RestTemplate restTemplate;
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        ClientRegistration graphRegistration = ClientRegistration
+                .withRegistrationId("graph")
+                .clientId("test-client-id")
+                .authorizationUri("authorizationUri")
+                .tokenUri("tokenUri")
+                .redirectUri("redirectUri")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .build();
+
+        return new InMemoryClientRegistrationRepository(graphRegistration);
+    }
+
+    @Bean
+    public OAuth2AuthorizedClientRepository authorizedClientRepository() {
+        return new HttpSessionOAuth2AuthorizedClientRepository();
+    }
+}

--- a/src/it/java/uk/gov/laa/gpfd/integration/ServerSideErrorIT.java
+++ b/src/it/java/uk/gov/laa/gpfd/integration/ServerSideErrorIT.java
@@ -1,33 +1,30 @@
 package uk.gov.laa.gpfd.integration;
 
-import com.microsoft.graph.models.User;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import uk.gov.laa.gpfd.graph.AzureGraphClient;
-import uk.gov.laa.gpfd.utils.FileUtils;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(locations = "classpath:application-test.yml")
-@SpringBootTest
 class ServerSideErrorIT {
 
     @Autowired
@@ -36,8 +33,16 @@ class ServerSideErrorIT {
     @Autowired
     private JdbcTemplate writeJdbcTemplate;
 
-    @MockitoBean
-    AzureGraphClient mockAzureGraphClient;
+    @BeforeAll
+    void setupDatabase() {
+        writeJdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS GPFD;");
+    }
+
+    @AfterAll
+    void resetDatabase() {
+        writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.REPORT_TRACKING");
+        writeJdbcTemplate.execute("DROP TABLE IF EXISTS GPFD.CSV_TO_SQL_MAPPING_TABLE");
+    }
 
     @Test
     void getReportsShouldReturn500WhenCannotConnectToDb() throws Exception {
@@ -49,7 +54,7 @@ class ServerSideErrorIT {
 
     @Test
     void getReportWithIdShouldReturn500WhenCannotConnectToDb() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/reports/0d4da9ec-b0b3-4371-af10-f375330d85d3")
+        MockHttpServletResponse response = mockMvc.perform(get("/reports/0d4da9ec-b0b3-4371-af10-f375330d85d9")
                 .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
 
         Assertions.assertEquals(500, response.getStatus());
@@ -57,7 +62,7 @@ class ServerSideErrorIT {
 
     @Test
     void getCsvWithIdShouldReturn500WhenCannotConnectToDbForMappingTable() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3")
+        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d9")
                 .with(oidcLogin()
                         .idToken(token -> token.subject("mockUser")))
                 .with(oauth2Client("graph"))).andReturn().getResponse();
@@ -67,31 +72,12 @@ class ServerSideErrorIT {
 
     @Test
     void getCsvWithIdShouldReturn500WhenCannotConnectToDbForReportTable() throws Exception {
-        setupGpfdDatabase();
-        User user = new User();
-        user.userPrincipalName = "Test User";
-
-        when(mockAzureGraphClient.getGraphUserDetails(any())).thenReturn(user);
-
-        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d3")
+        MockHttpServletResponse response = mockMvc.perform(MockMvcRequestBuilders.get("/csv/0d4da9ec-b0b3-4371-af10-f375330d85d9")
                 .with(oidcLogin()
                         .idToken(token -> token.subject("mockUser")))
                 .with(oauth2Client("graph"))).andReturn().getResponse();
 
         Assertions.assertEquals(500, response.getStatus());
-        resetDatabase();
     }
 
-    private void setupGpfdDatabase() {
-        String gpfdSqlSchema = FileUtils.readResourceToString("gpfd_schema.sql");
-        String gpfdSqlData = FileUtils.readResourceToString("gpfd_data.sql");
-        writeJdbcTemplate.execute(gpfdSqlSchema);
-        writeJdbcTemplate.execute(gpfdSqlData);
-    }
-
-    private void resetDatabase() {
-        writeJdbcTemplate.update("DROP TABLE GPFD.REPORT_TRACKING");
-        writeJdbcTemplate.update("DROP SEQUENCE GPFD_TRACKING_TABLE_SEQUENCE");
-        writeJdbcTemplate.update("DROP TABLE GPFD.CSV_TO_SQL_MAPPING_TABLE");
-    }
 }


### PR DESCRIPTION
This PR addresses the following:

- Extracted Integration Tests: Moved all integration tests to the `src/test/it` directory for better organization and maintainability.
- Fixed Classpath Issue: Updated the Maven Surefire Plugin configuration to correctly include tests from the `src/test/it` directory during the build process.

This change improves code organization and ensures that all integration tests are properly executed during the build.