### PR TITLE
LPF-602 - change network policy to allow Prometheus through

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - feature/LPF-602-network
 
 jobs:
 

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - feature/LPF-602-network
 
 jobs:
 

--- a/deployments/development/network-policy.tpl
+++ b/deployments/development/network-policy.tpl
@@ -4,9 +4,7 @@ metadata:
   name: allow-prometheus-scraping
   namespace: ${NAMESPACE}
 spec:
-  podSelector:
-    matchLabels:
-      app: gpfd-dev-service
+  podSelector: {}
   policyTypes:
   - Ingress
   ingress:

--- a/deployments/prod/network-policy.tpl
+++ b/deployments/prod/network-policy.tpl
@@ -4,9 +4,7 @@ metadata:
   name: allow-prometheus-scraping
   namespace: ${NAMESPACE}
 spec:
-  podSelector:
-    matchLabels:
-      app: gpfd-prod-service
+  podSelector: {}
   policyTypes:
   - Ingress
   ingress:

--- a/deployments/uat/network-policy.tpl
+++ b/deployments/uat/network-policy.tpl
@@ -4,9 +4,7 @@ metadata:
   name: allow-prometheus-scraping
   namespace: ${NAMESPACE}
 spec:
-  podSelector:
-    matchLabels:
-      app: gpfd-uat-service
+  podSelector: {}
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
Change Network Policy podselector to allow the monitoring namespace (prometheus) to access **any** pod in our namespace. Before it was only looking for our service pod, and so could not access our actuator endpoint.

This setup is used in network policies in many MoJ repos. 

We can see this works by comparing dev (where it is deployed) and uat (where it is not) - you can tell if Prometheus can access the metrics by looking at the targets section of Prometheus
<img width="946" alt="image" src="https://github.com/user-attachments/assets/bd9de486-817c-4554-8ed6-9bc84285f365" />

We can also test the metrics that were failing previously on the ticket, e.g. jvm_info
Works on Dev now
![image](https://github.com/user-attachments/assets/57c40919-9edd-4426-b027-e394ea90765d)

Doesn't on uat still
![image](https://github.com/user-attachments/assets/8a6bb4a3-473e-4e05-b353-72128778cb26)


