### PR TITLE
LPF-570 - fix docker scan

### DIFF
--- a/.github/workflows/scan_docker_image.yml
+++ b/.github/workflows/scan_docker_image.yml
@@ -6,6 +6,10 @@ on:
     # Run at 7:30AM UTC every day
     - cron:  '30 07 * * *'
 
+env:
+  USERNAME: ${{ secrets.OPENAPI_PACKAGE_USER }}
+  PASSWORD: ${{ secrets.OPENAPI_PACKAGE_PASSWORD }}
+
 jobs:
   scan-docker-image:
       permissions:
@@ -17,7 +21,7 @@ jobs:
         - uses: actions/checkout@v4
 
         - name: Build with Maven
-          run: mvn -B -DskipTests clean package
+          run: mvn -B -DskipTests clean package -s .github/settings.xml
           shell:
             bash
 


### PR DESCRIPTION
Docker scan fails due to the changes around the open api. example failure: https://github.com/ministryofjustice/payforlegalaid/actions/runs/13625682748/job/38082398692
![image](https://github.com/user-attachments/assets/aec12614-acc7-46f1-85cb-7e9a34b161bc)

Need to supply the settings.xml like we have on other pipelines to fix this
with fix: https://github.com/ministryofjustice/payforlegalaid/actions/runs/13587413293 
![image](https://github.com/user-attachments/assets/220ed861-dcac-4847-848c-def0bf3bce14)

