### PR TITLE
LPF-664 - auth changes to enable ui flow

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -52,6 +52,12 @@ public class AppConfig {
     @Value("${gpfd.allowed.redirect-uri}")
     private List<String> allowedRedirectUri;
 
+    /**
+     * Validates if a given URI is on the whitelist for allowed Redirect URIs, which is set in the application properties.
+     *
+     * @param testUri The URI that has been supplied as a redirect URI
+     * @return True if testUri is in the whitelist
+     */
     public boolean isValidRedirectUri(String testUri) {
         return allowedRedirectUri.contains(testUri);
     }
@@ -146,7 +152,6 @@ public class AppConfig {
     /**
      * Creates and configures a {@link SpringLiquibase} bean to be used for database,
      * if the property `spring.liquibase.enabled` is set to `true` in the application properties.
-     * <p>
      * This method will set the data source to the specified {@link DataSource} bean, configure the
      * change log file to be used by Liquibase, and ensure that the migrations are executed by
      * setting {@code setShouldRun(true)}.

--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 import java.util.List;
 
 /**
-* Configuration class for application-level beans and settings.
+ * Configuration class for application-level beans and settings.
  * <p>
  * This class defines various beans such as data sources, JDBC templates,
  * model mapper, and a RestTemplate with custom message converters. These configurations
@@ -48,6 +48,13 @@ public class AppConfig {
     @Getter
     @Value("${gpfd.url}")
     private String serviceUrl;
+
+    @Value("${gpfd.allowed.redirect-uri}")
+    private List<String> allowedRedirectUri;
+
+    public boolean isValidRedirectUri(String testUri) {
+        return allowedRedirectUri.contains(testUri);
+    }
 
     @Value("${spring.liquibase.changelog}")
     private String liquibaseChangeLog;
@@ -139,14 +146,13 @@ public class AppConfig {
     /**
      * Creates and configures a {@link SpringLiquibase} bean to be used for database,
      * if the property `spring.liquibase.enabled` is set to `true` in the application properties.
-     *
+     * <p>
      * This method will set the data source to the specified {@link DataSource} bean, configure the
      * change log file to be used by Liquibase, and ensure that the migrations are executed by
      * setting {@code setShouldRun(true)}.
      *
      * @param dataSource The {@link DataSource} bean to be used by Liquibase for database connectivity.
      * @return A configured {@link SpringLiquibase} instance ready for migration.
-     *
      * @see SpringLiquibase
      * @see DataSource
      */

--- a/src/main/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandler.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandler.java
@@ -1,0 +1,43 @@
+package uk.gov.laa.gpfd.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        log.debug("Authentication successful");
+
+        HttpSession session = request.getSession();
+
+        Object redirectUrlObject = session.getAttribute("redirect_uri");
+        Object savedRequestObject = session.getAttribute("SPRING_SECURITY_SAVED_REQUEST");
+
+        if (redirectUrlObject instanceof String redirectUrl && !redirectUrl.isEmpty()) {
+            // We passed a redirect url into our auth request (aka request is from the ui)
+            log.info("After authentication we are returning to the request redirect url");
+            response.sendRedirect(redirectUrl);
+        } else if (savedRequestObject instanceof SavedRequest savedRequest) {
+            // We came here from another part of the api, such as trying to load the /reports endpoint without being logged in
+            log.info("After authentication we are returning to their original url");
+            response.sendRedirect(savedRequest.getRedirectUrl());
+        } else {
+            // Else just let Spring do what it wants to do
+            log.info("After authentication, redirect to the default url");
+        }
+
+    }
+
+}

--- a/src/main/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandler.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandler.java
@@ -25,12 +25,12 @@ public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
         log.debug("Authentication successful");
 
         HttpSession session = request.getSession();
-        Object redirectUrlObject = session.getAttribute("redirect_uri");
+        Object redirectUriObject = session.getAttribute("redirect_uri");
         Object savedRequestObject = session.getAttribute("SPRING_SECURITY_SAVED_REQUEST");
 
         boolean validRedirectUri = false;
 
-        if (redirectUrlObject instanceof String redirectUri && !redirectUri.isEmpty()) {
+        if (redirectUriObject instanceof String redirectUri && !redirectUri.isEmpty()) {
             if (appConfig.isValidRedirectUri(redirectUri)) {
                 validRedirectUri = true;
             } else {
@@ -40,16 +40,16 @@ public class CustomAuthSuccessHandler implements AuthenticationSuccessHandler {
         }
 
         if (validRedirectUri) {
-            // We passed a redirect url into our auth request (aka request is from the ui) and it is whitelisted
-            log.info("After authentication we are returning to the request redirect url");
-            response.sendRedirect(redirectUrlObject.toString());
+            // We passed a redirect uri into our auth request (aka request is from the ui) and it is whitelisted
+            log.info("After authentication we are returning to the request's Redirect URI");
+            response.sendRedirect(redirectUriObject.toString());
         } else if (savedRequestObject instanceof SavedRequest savedRequest) {
             // We came here from another part of the api, such as trying to load the /reports endpoint without being logged in
-            log.info("After authentication we are returning to their original url");
+            log.info("After authentication we are returning to their original URI");
             response.sendRedirect(savedRequest.getRedirectUrl());
         } else {
             // Else just let Spring do what it wants to do - will probably be the redirect-uri-template
-            log.info("After authentication, redirect to the default url");
+            log.info("After authentication, redirect to the default URI");
         }
 
     }

--- a/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
@@ -9,11 +9,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 @AllArgsConstructor
 @Slf4j
+@Component
 class RedirectUriFilter implements Filter {
 
     AppConfig appConfig;

--- a/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
@@ -1,0 +1,37 @@
+package uk.gov.laa.gpfd.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+class RedirectUriFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+
+        // If a redirect URI is passed in, we need it after the auth journey is complete.
+        // The use case of this is the UI logging in and returning back to the UI.
+        // By filtering here, we can store the redirect uri before Spring throws it away
+        // Because there are multiple redirects happen between here and then as it goes through the Entra id journey
+        // We retrieve this value later on in the auth success handler
+
+        String redirectUri = httpServletRequest.getParameter("redirect_uri");
+        HttpSession session = httpServletRequest.getSession();
+
+        if (redirectUri != null && !redirectUri.isEmpty()) {
+            session.setAttribute("redirect_uri", redirectUri);
+            log.debug("Redirect URI was supplied and saved");
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/RedirectUriFilter.java
@@ -7,12 +7,16 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
+@AllArgsConstructor
 @Slf4j
 class RedirectUriFilter implements Filter {
+
+    AppConfig appConfig;
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
@@ -21,15 +25,18 @@ class RedirectUriFilter implements Filter {
         // If a redirect URI is passed in, we need it after the auth journey is complete.
         // The use case of this is the UI logging in and returning back to the UI.
         // By filtering here, we can store the redirect uri before Spring throws it away
+        // And ensure it matches our white list!
         // Because there are multiple redirects happen between here and then as it goes through the Entra id journey
         // We retrieve this value later on in the auth success handler
-
         String redirectUri = httpServletRequest.getParameter("redirect_uri");
-        HttpSession session = httpServletRequest.getSession();
 
-        if (redirectUri != null && !redirectUri.isEmpty()) {
+        if (appConfig.isValidRedirectUri(redirectUri)) {
+            HttpSession session = httpServletRequest.getSession();
+
             session.setAttribute("redirect_uri", redirectUri);
-            log.debug("Redirect URI was supplied and saved");
+            log.debug("Valid Redirect URI was supplied and saved");
+        } else if (redirectUri != null && !redirectUri.isEmpty()){
+            log.warn("Invalid Redirect URI was supplied: {}. This will not be followed and defaults will be used.", redirectUri);
         }
 
         filterChain.doFilter(servletRequest, servletResponse);

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -4,10 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import uk.gov.laa.gpfd.config.builders.AuthorizeHttpRequestsBuilder;
 import uk.gov.laa.gpfd.config.builders.SessionManagementConfigurerBuilder;
 
@@ -43,7 +42,7 @@ public class SecurityConfig {
      */
     private final SessionManagementConfigurerBuilder sessionManagementConfigurerBuilder;
 
-    private final AuthorizationManager<RequestAuthorizationContext> authManager;
+    private final CustomAuthSuccessHandler customAuthSuccessHandler;
 
     /**
      * Configures the {@link SecurityFilterChain} for the HTTP security settings.
@@ -60,6 +59,10 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
+                // Save any supplied redirect uri so we can use it later
+                .addFilterBefore(new RedirectUriFilter(), OAuth2AuthorizationRequestRedirectFilter.class)
+                // Handle redirecting after logging in
+                .oauth2Login(login -> login.successHandler(customAuthSuccessHandler))
                 .authorizeHttpRequests(authorizeHttpRequestsBuilder)    // Apply authorization rules
                 .sessionManagement(sessionManagementConfigurerBuilder)  // Apply session management configuration
                 .build();

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -25,6 +25,8 @@ import uk.gov.laa.gpfd.config.builders.SessionManagementConfigurerBuilder;
 @ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "true")
 public class SecurityConfig {
 
+    private final AppConfig appConfig;
+
     /**
      * The custom {@link AuthorizeHttpRequestsBuilder} responsible for configuring
      * the authorization rules for HTTP requests, such as which endpoints are publicly
@@ -60,7 +62,7 @@ public class SecurityConfig {
     SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 // Save any supplied redirect uri so we can use it later
-                .addFilterBefore(new RedirectUriFilter(), OAuth2AuthorizationRequestRedirectFilter.class)
+                .addFilterBefore(new RedirectUriFilter(appConfig), OAuth2AuthorizationRequestRedirectFilter.class)
                 // Handle redirecting after logging in
                 .oauth2Login(login -> login.successHandler(customAuthSuccessHandler))
                 .authorizeHttpRequests(authorizeHttpRequestsBuilder)    // Apply authorization rules

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,12 @@ gpfd:
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-dev
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
 
+  # URIs the UI can pass in as a valid redirect UI
+  # Can add multiple using comma separated list
+  allowed:
+  # TODO replace with UI baseURI for dev
+    redirect-uri: http://localhost:3000/redirect
+
   # DEV MOJFIN database config
   datasource:
     read-only:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,7 +7,7 @@ gpfd:
   # URIs the UI can pass in as a valid redirect UI
   # Can add multiple using comma separated list
   allowed:
-  # TODO replace with UI baseURI for dev
+  # replace with UI baseURI for dev
     redirect-uri: http://localhost:3000/redirect
 
   # DEV MOJFIN database config

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ gpfd:
   # URIs the UI can pass in as a valid redirect UI
   # Can add multiple using comma separated list
   allowed:
-    # TODO replace with UI baseURI for prod
+    # replace with UI baseURI for prod
     redirect-uri: http://localhost:3000/redirect
 
   # MOJFIN database config

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,12 @@ gpfd:
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-prod
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
 
+  # URIs the UI can pass in as a valid redirect UI
+  # Can add multiple using comma separated list
+  allowed:
+    # TODO replace with UI baseURI for prod
+    redirect-uri: http://localhost:3000/redirect
+
   # MOJFIN database config
   datasource:
     read-only:

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -5,7 +5,7 @@ gpfd:
   # URIs the UI can pass in as a valid redirect UI
   # Can add multiple using comma separated list
   allowed:
-    # TODO replace with UI baseURI for uat
+    # replace with UI baseURI for uat
     redirect-uri: http://localhost:3000/redirect
 
   # MOJFIN database config

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -2,6 +2,12 @@ gpfd:
   url: https://uat.get-legal-aid-data.service.justice.gov.uk
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-uat
 
+  # URIs the UI can pass in as a valid redirect UI
+  # Can add multiple using comma separated list
+  allowed:
+    # TODO replace with UI baseURI for uat
+    redirect-uri: http://localhost:3000/redirect
+
   # MOJFIN database config
   datasource:
     read-only:

--- a/src/test/java/uk/gov/laa/gpfd/config/AppConfigTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/AppConfigTest.java
@@ -18,13 +18,15 @@ import javax.sql.DataSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 @SpringBootTest(classes = AppConfig.class)
-@TestPropertySource(properties = { "gpfd.url=http://localhost"})
+@TestPropertySource(properties = {"gpfd.url=http://localhost", "gpfd.allowed.redirect-uri: http://localhost, http://localhos:3000"})
 class AppConfigTest {
 
     @Autowired
@@ -265,5 +267,19 @@ class AppConfigTest {
     void shouldReturnServiceUrl() {
 
         assertTrue(classUnderTest.getServiceUrl().contentEquals("http://localhost"));
+    }
+
+    @Test
+    void shouldReturnTrueIfUriIsInWhiteList() {
+
+        assertTrue(classUnderTest.isValidRedirectUri("http://localhos:3000"));
+
+    }
+
+    @Test
+    void shouldReturnFalseIfUriIsNotInWhiteList() {
+
+        assertFalse(classUnderTest.isValidRedirectUri("http://localhost:3000"));
+
     }
 }

--- a/src/test/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandlerTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandlerTest.java
@@ -1,0 +1,117 @@
+package uk.gov.laa.gpfd.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.savedrequest.SavedRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomAuthSuccessHandlerTest {
+
+    @InjectMocks
+    private final CustomAuthSuccessHandler customAuthSuccessHandler = new CustomAuthSuccessHandler();
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private Authentication mockAuthentication;
+
+    @Mock
+    private HttpSession mockSession;
+
+    @BeforeEach
+    public void beforeEach() {
+        reset(mockRequest, mockResponse, mockAuthentication, mockSession);
+        when(mockRequest.getSession()).thenReturn(mockSession);
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldFollowRedirectUrlIfDefinedAndNonEmpty() {
+
+        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("/hi");
+
+        customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
+
+        verify(mockResponse).sendRedirect("/hi");
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldFollowRedirectUrlIfDefinedAndSavedRequestAlsoDefined() {
+
+        SavedRequest savedRequest = mock(SavedRequest.class);
+
+        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("/hi");
+        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(savedRequest);
+
+        customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
+
+        verify(mockResponse).sendRedirect("/hi");
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldFollowSavedRequestIfDefinedAndRedirectUrlIsNot() {
+
+        SavedRequest savedRequest = mock(SavedRequest.class);
+
+        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn(null);
+        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(savedRequest);
+        when(savedRequest.getRedirectUrl()).thenReturn("/hello");
+
+        customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
+
+        verify(mockResponse).sendRedirect("/hello");
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldNotRedirectIfNeitherRedirectUriNorSavedRequestDefined() {
+
+        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn(null);
+        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(null);
+
+        customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
+
+        verify(mockResponse, times(0)).sendRedirect(any());
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldNotFollowRedirectUriIfItIsEmptyString() {
+
+        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("");
+        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(null);
+
+        customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
+
+        verify(mockResponse, times(0)).sendRedirect(any());
+
+    }
+
+}

--- a/src/test/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandlerTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/CustomAuthSuccessHandlerTest.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.savedrequest.SavedRequest;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -22,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class CustomAuthSuccessHandlerTest {
+class CustomAuthSuccessHandlerTest {
 
     @Mock
     private AppConfig appConfig;
@@ -43,17 +42,17 @@ public class CustomAuthSuccessHandlerTest {
     private HttpSession mockSession;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         reset(mockRequest, mockResponse, mockAuthentication, mockSession, appConfig);
         when(mockRequest.getSession()).thenReturn(mockSession);
     }
 
     @SneakyThrows
     @Test
-    public void shouldFollowRedirectUrlIfDefinedAndNonEmptyAndWhiteListed() {
+    void shouldFollowRedirectUrlIfDefinedAndNonEmptyAndWhiteListed() {
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("/hi");
-        when(appConfig.isValidRedirectUri(eq("/hi"))).thenReturn(true);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn("/hi");
+        when(appConfig.isValidRedirectUri("/hi")).thenReturn(true);
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
 
@@ -63,10 +62,10 @@ public class CustomAuthSuccessHandlerTest {
 
     @SneakyThrows
     @Test
-    public void shouldNotFollowRedirectUrlIfNotWhiteListed() {
+    void shouldNotFollowRedirectUrlIfNotWhiteListed() {
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("/hi");
-        when(appConfig.isValidRedirectUri(eq("/hi"))).thenReturn(false);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn("/hi");
+        when(appConfig.isValidRedirectUri("/hi")).thenReturn(false);
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
 
@@ -76,13 +75,13 @@ public class CustomAuthSuccessHandlerTest {
 
     @SneakyThrows
     @Test
-    public void shouldFollowRedirectUrlIfDefinedAndSavedRequestAlsoDefined() {
+    void shouldFollowRedirectUrlIfDefinedAndSavedRequestAlsoDefined() {
 
         SavedRequest savedRequest = mock(SavedRequest.class);
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("/hi");
-        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(savedRequest);
-        when(appConfig.isValidRedirectUri(eq("/hi"))).thenReturn(true);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn("/hi");
+        when(mockSession.getAttribute("SPRING_SECURITY_SAVED_REQUEST")).thenReturn(savedRequest);
+        when(appConfig.isValidRedirectUri("/hi")).thenReturn(true);
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
 
@@ -92,12 +91,12 @@ public class CustomAuthSuccessHandlerTest {
 
     @SneakyThrows
     @Test
-    public void shouldFollowSavedRequestIfDefinedAndRedirectUrlIsNot() {
+    void shouldFollowSavedRequestIfDefinedAndRedirectUrlIsNot() {
 
         SavedRequest savedRequest = mock(SavedRequest.class);
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn(null);
-        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(savedRequest);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn(null);
+        when(mockSession.getAttribute("SPRING_SECURITY_SAVED_REQUEST")).thenReturn(savedRequest);
         when(savedRequest.getRedirectUrl()).thenReturn("/hello");
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
@@ -108,10 +107,10 @@ public class CustomAuthSuccessHandlerTest {
 
     @SneakyThrows
     @Test
-    public void shouldNotRedirectIfNeitherRedirectUriNorSavedRequestDefined() {
+    void shouldNotRedirectIfNeitherRedirectUriNorSavedRequestDefined() {
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn(null);
-        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(null);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn(null);
+        when(mockSession.getAttribute("SPRING_SECURITY_SAVED_REQUEST")).thenReturn(null);
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
 
@@ -121,10 +120,10 @@ public class CustomAuthSuccessHandlerTest {
 
     @SneakyThrows
     @Test
-    public void shouldNotFollowRedirectUriIfItIsEmptyString() {
+    void shouldNotFollowRedirectUriIfItIsEmptyString() {
 
-        when(mockSession.getAttribute(eq("redirect_uri"))).thenReturn("");
-        when(mockSession.getAttribute(eq("SPRING_SECURITY_SAVED_REQUEST"))).thenReturn(null);
+        when(mockSession.getAttribute("redirect_uri")).thenReturn("");
+        when(mockSession.getAttribute("SPRING_SECURITY_SAVED_REQUEST")).thenReturn(null);
 
         customAuthSuccessHandler.onAuthenticationSuccess(mockRequest, mockResponse, mockAuthentication);
 

--- a/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,7 +68,7 @@ class RedirectUriFilterTest {
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
+        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
 
     }
 
@@ -80,7 +81,7 @@ class RedirectUriFilterTest {
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
+        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
 
     }
 
@@ -92,7 +93,7 @@ class RedirectUriFilterTest {
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
+        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
 
     }
 

--- a/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
@@ -1,0 +1,81 @@
+package uk.gov.laa.gpfd.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RedirectUriFilterTest {
+
+    @InjectMocks
+    private final RedirectUriFilter redirectUriFilter = new RedirectUriFilter();
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private FilterChain mockFilterChain;
+
+    @Mock
+    private HttpSession mockSession;
+
+    @BeforeEach
+    public void beforeEach() {
+        reset(mockRequest, mockResponse, mockFilterChain, mockSession);
+        when(mockRequest.getSession()).thenReturn(mockSession);
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldStoreRedirectUriIfSupplied() {
+
+        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn("/hi");
+
+        redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockSession).setAttribute(eq("redirect_uri"), eq("/hi"));
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldNotAttemptToStoreRedirectUriIfNotSet() {
+
+        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn(null);
+
+        redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
+
+    }
+
+    @SneakyThrows
+    @Test
+    public void shouldNotAttemptToStoreRedirectUriIfEmptyString() {
+
+        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn("");
+
+        redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
+
+    }
+}

--- a/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/RedirectUriFilterTest.java
@@ -13,14 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class RedirectUriFilterTest {
+class RedirectUriFilterTest {
 
     @Mock
     private AppConfig appConfig;
@@ -41,59 +40,59 @@ public class RedirectUriFilterTest {
     private HttpSession mockSession;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         reset(mockRequest, mockResponse, mockFilterChain, mockSession);
     }
 
     @SneakyThrows
     @Test
-    public void shouldStoreRedirectUriIfSuppliedAndWhiteListed() {
+    void shouldStoreRedirectUriIfSuppliedAndWhiteListed() {
 
-        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn("/hi");
-        when(appConfig.isValidRedirectUri(eq("/hi"))).thenReturn(true);
+        when(mockRequest.getParameter("redirect_uri")).thenReturn("/hi");
+        when(appConfig.isValidRedirectUri("/hi")).thenReturn(true);
         when(mockRequest.getSession()).thenReturn(mockSession);
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession).setAttribute(eq("redirect_uri"), eq("/hi"));
+        verify(mockSession).setAttribute("redirect_uri", "/hi");
 
     }
 
     @SneakyThrows
     @Test
-    public void shouldNotAttemptToStoreRedirectUriIfNotWhiteListed() {
+    void shouldNotAttemptToStoreRedirectUriIfNotWhiteListed() {
 
-        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn("/hi");
-        when(appConfig.isValidRedirectUri(eq("/hi"))).thenReturn(false);
+        when(mockRequest.getParameter("redirect_uri")).thenReturn("/hi");
+        when(appConfig.isValidRedirectUri("/hi")).thenReturn(false);
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
+        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
 
     }
 
 
     @SneakyThrows
     @Test
-    public void shouldNotAttemptToStoreRedirectUriIfNotSet() {
+    void shouldNotAttemptToStoreRedirectUriIfNotSet() {
 
-        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn(null);
+        when(mockRequest.getParameter("redirect_uri")).thenReturn(null);
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
+        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
 
     }
 
     @SneakyThrows
     @Test
-    public void shouldNotAttemptToStoreRedirectUriIfEmpty() {
+    void shouldNotAttemptToStoreRedirectUriIfEmpty() {
 
-        when(mockRequest.getParameter(eq("redirect_uri"))).thenReturn("");
+        when(mockRequest.getParameter("redirect_uri")).thenReturn("");
 
         redirectUriFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(mockSession, times(0)).setAttribute(eq("redirect_uri"), any());
+        verify(mockSession, times(0)).setAttribute("redirect_uri", any());
 
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,12 @@
 gpfd:
   url: http://localhost
   redirect-uri-template: http://localhost:8080
+
+  # URIs the UI can pass in as a valid redirect UI
+  # Can add multiple using comma separated list
+  allowed:
+    redirect-uri: http://localhost:3000/redirect
+
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
   datasource:
@@ -14,7 +20,6 @@ gpfd:
       username: sa
       password:
       driver-class-name: org.h2.Driver
-
 
 # Azure AD and Graph config
 spring:

--- a/src/test/resources/application-testauth.yml
+++ b/src/test/resources/application-testauth.yml
@@ -2,6 +2,12 @@ gpfd:
   url: http://localhost
   redirect-uri-template: http://localhost:8080
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
+
+  # URIs the UI can pass in as a valid redirect UI
+  # Can add multiple using comma separated list
+  allowed:
+    redirect-uri: http://localhost:3000/redirect
+
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
   datasource:
     read-only:


### PR DESCRIPTION
Changes are as follows:

### UI flow
User goes to UI.
It makes a call to the api, /requests endpoint
There is no authentication at this point, so the api returns a **302 redirect** with a **link to the Entra login page**
The UI **follows** this redirect, appending a **redirect_uri** to send it back home to the UI afterwards
The Spring security intercepts this in the new **RedirectUriFilter** class, checks it against a **whitelist**, and if it is on the list it will **save it for later** use (because otherwise it will get lost during the OAuth2 journey)
After a successful request, the redirect uri is retrieved from the session (checked validity again) and navigated to, sending the user back to the UI.  This is inside the **CustomAuthSuccessHandler**.

https://github.com/user-attachments/assets/f60af00a-0647-4405-a934-53197ea9b154

#### Whitelist
The whitelist is set in the application.yml: gpfd.allowed.redirect-uri, in comma separated list format.

### API flow
Firstly, note that before this PR, if you call say the dev instance of the api with the /reports endpoint before logging in it takes you to a useless page and you have to return to /reports manually
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/8f277b7f-9aed-454a-a2e8-dcb71c367d75" />

Now:
You enter /reports in the browser url, you have no logged in yet
Get **redirected to Entra** and follow that journey
Afterwards, in the newly introduced **CustomAuthSuccessHandler** (see above), we use the **StoredRequest** - this was the original unauthed request from step 1. It tells us what the user was trying to access before they had to login, so we can send them back there.

https://github.com/user-attachments/assets/9ad723d3-baea-46b5-9333-5398e43e3a15


### Edge cases
If you are in neither of those cases, that means you have just for reasons unbeknownst to me, gone straight to the login address /oauth2/authorization/azure
In this case, we just let Spring continue its default behaviour, which will be to send your to the redirect uri defined in the application properties.
If the redirect_uri parameter passed into the /oauth2/authorization/azure request is not on the whitelist, it will log a warning, and ignore it - so go back to default spring behaviour

### Notes
If you login accessing the ui, and then go and access the api directly from the browser, you are still logged in and don't have to repeat (and vice versa)

### Testing
To test locally you need to setup your application.yml to have the development azure setup.