### PR TITLE
Get template from SDS mock

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -17,6 +17,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import uk.gov.laa.gpfd.model.FieldAttributes;
 import uk.gov.laa.gpfd.services.DataStreamer;
 import uk.gov.laa.gpfd.services.TemplateService;
@@ -178,6 +179,13 @@ public class AppConfig {
     @Bean
     public TemplateClient localTemplateClient() {
         return new LocalTemplateClient();
+    }
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        //TODO add var instead of hardcoding
+        // TODO add docs
+        return builder.baseUrl("https//localhost:8080").build();
     }
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -182,11 +182,14 @@ public class AppConfig {
     }
 
     @Bean
-    public WebClient webClient(WebClient.Builder builder) {
-        //TODO add var instead of hardcoding
+    public WebClient.Builder webClient() {
         // TODO add docs
-        return builder.baseUrl("https//localhost:8080").build();
+        return WebClient.builder();
     }
+
+    @Getter
+    @Value("${gpfd.sds-url}")
+    private String sdsUrl;
 
     /**
      * Creates a {@link TemplateService} bean that delegates to the provided {@link TemplateClient}

--- a/src/main/java/uk/gov/laa/gpfd/services/excel/template/LocalTemplateClient.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/excel/template/LocalTemplateClient.java
@@ -8,6 +8,8 @@ import static uk.gov.laa.gpfd.exception.TemplateResourceException.LocalTemplateR
 
 public record LocalTemplateClient() implements TemplateClient {
 
+    //TODO need to do stuff in here
+
     @Override
     @SneakyThrows
     public InputStream findTemplateById(String id) {

--- a/src/main/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClient.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClient.java
@@ -1,35 +1,51 @@
 package uk.gov.laa.gpfd.services.excel.template;
 
+import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import uk.gov.laa.gpfd.config.AppConfig;
 import uk.gov.laa.gpfd.exception.TemplateResourceException;
 
 import java.io.InputStream;
 
 @Component
 @Slf4j
+@AllArgsConstructor
 public class SdsTemplateClient implements TemplateClient {
 
-    private final WebClient webClient;
-
-    public SdsTemplateClient(WebClient client) {
-        this.webClient = client;
-    }
+    private final AppConfig appConfig;
+    private final WebClient.Builder webClientBuilder;
 
     @Override
     @SneakyThrows
     public InputStream findTemplateById(String id) {
-        //TODO call mock api with string id key
         InputStream response;
         try {
-            response = webClient.get().uri("/get_file?file_key=" + id).retrieve().bodyToMono(InputStream.class).block();
+            var webClient = webClientBuilder.baseUrl(getUrlFromSecureDocumentStorage(id)).build();
+            response = webClient.get().uri("").retrieve().bodyToMono(InputStream.class).block();
+        } catch (TemplateResourceException ex) {
+            log.error("Error occurred getting url from Secure Document Storage: %s", ex);
+            throw ex;
         } catch (Exception ex) {
-            log.error("Error occurred during template download: %s", ex);
+            log.error("Error occurred during template download:", ex);
             throw new TemplateResourceException.TemplateDownloadException("Unable to download template with id " + id);
         }
+
         return response;
+    }
+
+    private String getUrlFromSecureDocumentStorage(String fileKey) {
+        String url;
+        try {
+            var webClient = webClientBuilder.baseUrl(appConfig.getSdsUrl()).build();
+            url = webClient.get().uri("/get_file?file_key=" + fileKey).retrieve().bodyToMono(String.class).block();
+        } catch (Exception ex) {
+            throw new TemplateResourceException.TemplateDownloadException("Unable to get url for download of template with id " + fileKey);
+        }
+
+        return url;
     }
 
 }

--- a/src/main/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClient.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClient.java
@@ -1,0 +1,36 @@
+package uk.gov.laa.gpfd.services.excel.template;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import uk.gov.laa.gpfd.exception.TemplateResourceException;
+
+import java.io.InputStream;
+
+@Component
+@Slf4j
+public class SdsTemplateClient implements TemplateClient {
+
+    private final WebClient webClient;
+
+    public SdsTemplateClient(WebClient client) {
+        this.webClient = client;
+    }
+
+    @Override
+    @SneakyThrows
+    public InputStream findTemplateById(String id) {
+        //TODO call mock api with string id key
+        InputStream response;
+        try {
+            response = webClient.get().uri("/get_file?file_key=" + id).retrieve().bodyToMono(InputStream.class).block();
+        } catch (Exception ex) {
+            log.error("Error occurred during template download: %s", ex);
+            throw new TemplateResourceException.TemplateDownloadException("Unable to download template with id " + id);
+        }
+        return response;
+    }
+
+}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,7 @@
 gpfd:
   url: ${GPFD_URL}
+#  TODO will need more work
+  sds-url: ${GPFD_SDS_URL}
   #This is the url which the Active directory dev app registration will redirect to after SSO is complete
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-dev
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'

--- a/src/test/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClientTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClientTest.java
@@ -4,64 +4,112 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import uk.gov.laa.gpfd.config.AppConfig;
 import uk.gov.laa.gpfd.exception.TemplateResourceException;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SdsTemplateClientTest {
 
     @Mock
-    WebClient webClient;
+    WebClient.Builder webClientBuilder;
 
     @Mock
-    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+    WebClient sdsWebClient;
 
     @Mock
-    private WebClient.RequestHeadersSpec requestHeadersSpec;
+    private WebClient.RequestHeadersUriSpec sdsRequestHeadersUriSpec;
 
     @Mock
-    private WebClient.ResponseSpec responseSpec;
+    private WebClient.RequestHeadersSpec sdsRequestHeadersSpec;
 
+    @Mock
+    private WebClient.ResponseSpec sdsResponseSpec;
+
+    @Mock
+    WebClient awsWebClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec awsRequestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec awsRequestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec awsResponseSpec;
+    @Mock
+    AppConfig appConfig;
+
+    @InjectMocks
     private SdsTemplateClient sdsTemplateClient;
 
     @BeforeEach
     void setup() {
-        sdsTemplateClient = new SdsTemplateClient(webClient);
-    }
+        var fileName = "excelTemplate.xlsx";
+        var urlFromSds = "This is file URL";
+        var sdsUrl = "http//localhost:8080";
 
+        when(appConfig.getSdsUrl()).thenReturn(sdsUrl);
+        when(webClientBuilder.baseUrl(any())).thenReturn(webClientBuilder);
+
+        when(webClientBuilder.baseUrl(sdsUrl)).thenReturn(webClientBuilder);
+        when(webClientBuilder.baseUrl(urlFromSds)).thenReturn(webClientBuilder);
+
+        when(webClientBuilder.build()).thenReturn(sdsWebClient).thenReturn(awsWebClient);
+
+        when(sdsWebClient.get()).thenReturn(sdsRequestHeadersUriSpec);
+        when(sdsRequestHeadersUriSpec.uri("/get_file?file_key=" + fileName)).thenReturn(sdsRequestHeadersSpec);
+        when(sdsRequestHeadersSpec.retrieve()).thenReturn(sdsResponseSpec);
+
+    }
     @Test
     void findTemplateByIdReturnsTemplateAsInputStream() {
         var fileName = "excelTemplate.xlsx";
-        String mockFileContent = "This is a mock file content.";
+        var mockFileContent = "This is a mock file content.";
+        var urlFromSds = "This is file URL";
         InputStream mockInputStream = new ByteArrayInputStream(mockFileContent.getBytes());
 
-        when(webClient.get()).thenReturn(requestHeadersUriSpec);
-        when(requestHeadersUriSpec.uri("/get_file?file_key=" + fileName)).thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.bodyToMono(InputStream.class)).thenReturn(Mono.just(mockInputStream));
+        when(sdsResponseSpec.bodyToMono(String.class)).thenReturn(Mono.just(urlFromSds));
+
+        when(awsWebClient.get()).thenReturn(awsRequestHeadersUriSpec);
+        when(awsRequestHeadersUriSpec.uri("")).thenReturn(awsRequestHeadersSpec);
+        when(awsRequestHeadersSpec.retrieve()).thenReturn(awsResponseSpec);
+        when(awsResponseSpec.bodyToMono(InputStream.class)).thenReturn(Mono.just(mockInputStream));
 
         Assertions.assertEquals(mockInputStream, sdsTemplateClient.findTemplateById(fileName));
     }
 
     @Test
-    void shouldThrowWhenWebClientThrows() {
+    void shouldThrowWhenGetTemplateFromUrl() {
         var fileName = "excelTemplate.xlsx";
+        var urlFromSds = "This is file URL";
 
-        when(webClient.get()).thenReturn(requestHeadersUriSpec);
-        when(requestHeadersUriSpec.uri("/get_file?file_key=" + fileName)).thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.bodyToMono(InputStream.class)).thenThrow(IllegalArgumentException.class);
+        when(sdsResponseSpec.bodyToMono(String.class)).thenReturn(Mono.just(urlFromSds));
 
         var ex = Assertions.assertThrows(TemplateResourceException.TemplateDownloadException.class, () -> sdsTemplateClient.findTemplateById(fileName));
         Assertions.assertEquals("Unable to download template with id excelTemplate.xlsx", ex.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenGetUrlFromSDSThrows() {
+        var fileName = "excelTemplate.xlsx";
+        var sdsUrl = "http//localhost:8080";
+
+        when(sdsResponseSpec.bodyToMono(InputStream.class)).thenThrow(IllegalArgumentException.class);
+
+        var ex = Assertions.assertThrows(TemplateResourceException.TemplateDownloadException.class, () -> sdsTemplateClient.findTemplateById(fileName));
+        Assertions.assertEquals("Unable to get url for download of template with id excelTemplate.xlsx", ex.getMessage());
     }
 
 }

--- a/src/test/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClientTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/services/excel/template/SdsTemplateClientTest.java
@@ -1,0 +1,67 @@
+package uk.gov.laa.gpfd.services.excel.template;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import uk.gov.laa.gpfd.exception.TemplateResourceException;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SdsTemplateClientTest {
+
+    @Mock
+    WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private SdsTemplateClient sdsTemplateClient;
+
+    @BeforeEach
+    void setup() {
+        sdsTemplateClient = new SdsTemplateClient(webClient);
+    }
+
+    @Test
+    void findTemplateByIdReturnsTemplateAsInputStream() {
+        var fileName = "excelTemplate.xlsx";
+        String mockFileContent = "This is a mock file content.";
+        InputStream mockInputStream = new ByteArrayInputStream(mockFileContent.getBytes());
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/get_file?file_key=" + fileName)).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(InputStream.class)).thenReturn(Mono.just(mockInputStream));
+
+        Assertions.assertEquals(mockInputStream, sdsTemplateClient.findTemplateById(fileName));
+    }
+
+    @Test
+    void shouldThrowWhenWebClientThrows() {
+        var fileName = "excelTemplate.xlsx";
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/get_file?file_key=" + fileName)).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(InputStream.class)).thenThrow(IllegalArgumentException.class);
+
+        var ex = Assertions.assertThrows(TemplateResourceException.TemplateDownloadException.class, () -> sdsTemplateClient.findTemplateById(fileName));
+        Assertions.assertEquals("Unable to download template with id excelTemplate.xlsx", ex.getMessage());
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,6 @@
 gpfd:
   url: http://localhost
+  sds-url: http://localhost:8080
   redirect-uri-template: http://localhost:8080
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle

--- a/src/test/resources/application-testauth.yml
+++ b/src/test/resources/application-testauth.yml
@@ -1,5 +1,6 @@
 gpfd:
   url: http://localhost
+  sds-url: http://localhost:8080
   redirect-uri-template: http://localhost:8080
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle


### PR DESCRIPTION
* Get template using id, from SDS mock service
* gpfd will call SDS mock service (eventually replaced by real secure document service), get url for required template and then call url to get temaplte as input stream
* SDS endpoint is currently `/retrieve_file` but will soon become `/get_file` - we are using new endpoint name for future proofing
* `/get_file` returns presigned URL from AWS with default expiry as string
* 