### PR TITLE
LPF-914 - get docker scan working without a PAT key

### DIFF
--- a/.github/build-and-test/action.yml
+++ b/.github/build-and-test/action.yml
@@ -14,19 +14,10 @@ runs:
         java-version: '17'
         cache: 'maven'
 
-    - name: Checkout GitHub repository
-      uses: actions/checkout@v4
-      with:
-        repository: ministryofjustice/payforlegalaid-swagger
-        path: spec
-        ssh-key: ${{ env.SOCKET_KEY }}
-
-    - name: Build dependency
-      run: |
-        cd spec
-        mvn clean install -Dmaven.repo.local=${{ github.workspace }}/.m2/repository
-      shell:
-        bash
+    - name: Build OpenAPI dependency
+      uses: './.github/checkout-build-openapi'
+      env:
+        SOCKET_KEY: ${{ env.SOCKET_KEY }}
 
     - name: Run tests
       run: |

--- a/.github/checkout-build-openapi/action.yml
+++ b/.github/checkout-build-openapi/action.yml
@@ -1,0 +1,26 @@
+name: Checkout and build OpenAPI repository
+
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'corretto'
+        java-version: '17'
+        cache: 'maven'
+
+    - name: Checkout OpenAPI repository
+      uses: actions/checkout@v4
+      with:
+        repository: ministryofjustice/payforlegalaid-openapi
+        path: spec
+        ssh-key: ${{ env.SOCKET_KEY }}
+
+    - name: Build dependency
+      run: |
+        cd spec
+        mvn clean install -Dmaven.repo.local=${{ github.workspace }}/.m2/repository
+      shell:
+        bash

--- a/.github/workflows/scan_docker_image.yml
+++ b/.github/workflows/scan_docker_image.yml
@@ -16,8 +16,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
 
-        - name: Build and test
-          uses: './.github/build-and-test'
+        - name: Build OpenAPI dependency
+          uses: './.github/checkout-build-openapi'
           env:
             SOCKET_KEY: ${{ secrets.DEV_API_SOCKET_KEY }}
 

--- a/.github/workflows/scan_docker_image.yml
+++ b/.github/workflows/scan_docker_image.yml
@@ -6,10 +6,6 @@ on:
     # Run at 7:30AM UTC every day
     - cron:  '30 07 * * *'
 
-env:
-  USERNAME: ${{ secrets.OPENAPI_PACKAGE_USER }}
-  PASSWORD: ${{ secrets.OPENAPI_PACKAGE_PASSWORD }}
-
 jobs:
   scan-docker-image:
       permissions:
@@ -19,6 +15,11 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
+
+        - name: Build and test
+          uses: './.github/build-and-test'
+          env:
+            SOCKET_KEY: ${{ secrets.DEV_API_SOCKET_KEY }}
 
         - name: Build with Maven
           run: mvn -B -DskipTests clean package -s .github/settings.xml


### PR DESCRIPTION
Extract out the previous change to use a ssh key to a common action, and use that in the docker container snyk scan, which has been failing since the removal of the PATs.

The docker container scan now runs and passes, see e.g. https://github.com/ministryofjustice/payforlegalaid/actions/runs/15467958561