### PR TITLE
LPF-1023 - use templates while running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /dataSources/
 /dataSources.local.xml
 
+# Templates used for local testing should not be committed
+**/src/main/resources/**/*.xlsx
+
 HELP.md
 target/
 !.mvn/wrapper/maven-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -89,19 +89,18 @@ More information can be found in the following confluence page:
 https://dsdmoj.atlassian.net/wiki/spaces/LPF/pages/4736516940/GPFD+Environments
 
 ## Running The App
-
+### Locally
+Locally you can install the app and run it
 - `mvn clean install`
-
 - `java -jar -Dspring.profiles.active=local target/pay-for-legal-aid-0.0.1-SNAPSHOT-exec.jar`
 
-- This application is in an MVP state and currently does not have a local run setup, but some of the unit tests run
-  against an H2 database, which could be used to create a local run configuration.
+This makes use of a local h2 database. You can create one via running the acceptance tests.
 
-- There is currently a gpfd-ssl-keystore.p12 and custom ssl key used in the application (despite cloud platform
-  providing its own TLS protection on the platform level), because a https url is required by the Active Directory
-  server /app registration. A cloud platform-managed TLS cert should be used in the test environments in future, and there is a task in the
-  backlog for this. It is mandatory in PROD.
+You will need to populate the `src/main/resources` folder with any template files you need. These are the `.xlsx` files that
+hold a skeleton of the report in. E.g. if you want to test the Third Party Report you should place a copy of the Third Party Report template in the folder.
+For more details on how to get this template visit the [Confluence](https://dsdmoj.atlassian.net/wiki/spaces/LPF/pages/5803409516/How+to+create+a+template#How-do-I-get-a-template-to-use-on-my-local-system)
 
+### Access on development
 - There is a shared password-manager group account for the GPFD team, ask the manager of the team for access. This group has a number of test users which can be used to access the Dev environment - these accounts have been registered with the DEV environment's active directory, and so will pass the SSO authentication.
 
 ## Tests

--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -105,10 +105,12 @@ public class AppConfig {
     public DataSource readOnlyDataSource(
             @Value("${gpfd.datasource.read-only.url}") String url,
             @Value("${gpfd.datasource.read-only.username}") String username,
-            @Value("${gpfd.datasource.read-only.password}") String password
+            @Value("${gpfd.datasource.read-only.password}") String password,
+            @Value("${gpfd.datasource.read-only.driver-class-name}") String driverClass
     ) throws SQLException {
         PoolDataSource pds = PoolDataSourceFactory.getPoolDataSource();
-        pds.setConnectionFactoryClassName("oracle.jdbc.pool.OracleDataSource");
+
+        pds.setConnectionFactoryClassName(driverClass);
         pds.setURL(url);
         pds.setUser(username);
         pds.setPassword(password);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,12 +10,12 @@ gpfd:
           url: ${MOJFIN_DB_URL}
           username: ${MOJFIN_DEV_READ_USERNAME}
           password: ${MOJFIN_DEV_READ_PASSWORD}
-          driver-class-name: oracle.jdbc.OracleDriver
+          driver-class-name: oracle.jdbc.pool.OracleDataSource
     write:
       url: ${MOJFIN_DB_URL}
       username: ${MOJFIN_DEV_WRITE_USERNAME}
       password: ${MOJFIN_DEV_WRITE_PASSWORD}
-      driver-class-name: oracle.jdbc.OracleDriver
+      driver-class-name: oracle.jdbc.pool.OracleDataSource
 
 
 # Azure AD and Graph config

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,12 +10,12 @@ gpfd:
           url: ${MOJFIN_DB_URL}
           username: ${MOJFIN_DEV_READ_USERNAME}
           password: ${MOJFIN_DEV_READ_PASSWORD}
-          driver-class-name: oracle.jdbc.OracleDriver
+          driver-class-name: oracle.jdbc.pool.OracleDataSource
     write:
       url: ${MOJFIN_DB_URL}
       username: ${MOJFIN_DEV_WRITE_USERNAME}
       password: ${MOJFIN_DEV_WRITE_PASSWORD}
-      driver-class-name: oracle.jdbc.OracleDriver
+      driver-class-name: oracle.jdbc.pool.OracleDataSource
 
 # Azure AD and Graph config
 spring:

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -8,12 +8,12 @@ gpfd:
       url: ${MOJFIN_DB_URL}
       username: ${MOJFIN_DEV_READ_USERNAME}
       password: ${MOJFIN_DEV_READ_PASSWORD}
-      driver-class-name: oracle.jdbc.OracleDriver
+      driver-class-name: oracle.jdbc.pool.OracleDataSource
     write:
       url: ${MOJFIN_DB_URL}
       username: ${MOJFIN_DEV_WRITE_USERNAME}
       password: ${MOJFIN_DEV_WRITE_PASSWORD}
-      driver-class-name: oracle.jdbc.OracleDriver
+      driver-class-name: oracle.jdbc.pool.OracleDataSource
 
 spring:
   cloud:


### PR DESCRIPTION
JIRA: [LPF-1023](https://dsdmoj.atlassian.net/browse/LPF-1023)

## Description of changes
- The current framework already provides the capability to run locally if you put your templates in the `src/main/resources` folder
- Future changes to the app config affecting local will be necessary for LPF-1024 but it is unnecessary to predict them at this stage.
- Stop you uploading to git templates via the .gitignore
- Update README
- Update Confluence guide to running locally
- Fix bug https://dsdmoj.atlassian.net/browse/LPF-965 - update the driver config for non-local systems and replace the hardcoded driver with the app-config

## Evidence
N/A

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history