### PR TITLE
LPF-636 - avoid Double-Brace Initialisation

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -262,12 +262,15 @@ public class AppConfig {
      */
     @Bean
     RestTemplate restTemplate() {
-        return new RestTemplate() {{
-            setMessageConverters(List.of(
-                    new StringHttpMessageConverter(),
-                    new ByteArrayHttpMessageConverter()
-            ));
-        }};
+        var restTemplate = new RestTemplate();
+        restTemplate.setMessageConverters(
+                List.of(
+                        new StringHttpMessageConverter(),
+                        new ByteArrayHttpMessageConverter()
+                )
+        );
+
+        return restTemplate;
     }
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/controller/ReportsController.java
+++ b/src/main/java/uk/gov/laa/gpfd/controller/ReportsController.java
@@ -45,9 +45,8 @@ public class ReportsController implements ReportsApi, ExcelApi, CsvApi {
     public ResponseEntity<ReportsGet200Response> reportsGet() {
         var reportListEntries = reportManagementService.fetchReportListEntries();
 
-        var response = new ReportsGet200Response() {{
-            reportListEntries.forEach(this::addReportListItem);
-        }};
+        var response = new ReportsGet200Response();
+        reportListEntries.forEach(response::addReportListItem);
 
         log.debug("Returning a reportListResponse to user");
         return ResponseEntity.ok(response);


### PR DESCRIPTION
JIRA: [LPF-636](https://dsdmoj.atlassian.net/browse/LPF-636)

## Description of changes
- Resolve Sonar warnings about double-brace initialisation
- While our uses are probably harmless, it is easy to accidentally end up with memory leaks and can increase compiler load, especially when people who aren't familiar with the intricacies of them change code around them. See [this blog](https://blog.jooq.org/dont-be-clever-the-double-curly-braces-anti-pattern/) for more thoughts on them

## Evidence
- Tests still pass

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history

[LPF-636]: https://dsdmoj.atlassian.net/browse/LPF-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ