### PR TITLE
LPF-1384 - Added warning suppression for CodeQL

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriter.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriter.java
@@ -127,6 +127,10 @@ public final class ReportSheetDataWriter extends SheetDataWriter implements Clos
      * @throws IOException if an I/O error occurs
      */
     @Override
+    @SuppressWarnings("java/missing-case-in-switch")
+    /*
+    Suppressing warning about missing values in the switch cases so CodeQL can ignore them.
+     */
     public void writeCell(int columnIndex, Cell cell) throws IOException {
         if (cell == null) {
             return;


### PR DESCRIPTION
JIRA: [LPF-1384](https://dsdmoj.atlassian.net/browse/LPF-1384)

## Description of changes
CodeQL is complaining about a switch case not having all the values. Due to this class being an extension of the `SheetDataWriter` class, and due to it not being able to handle the `_NONE` value as a valid case, we have chosen to suppress the warning.

- https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/164
- https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/165

- Added a suppress warning annotation at method level to prevent CodeQL from raising issues

## Checklist
- [X] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1384]: https://dsdmoj.atlassian.net/browse/LPF-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ