### PR TITLE
Tooling:LPF-1379 add JaCoCo coverage threshold and quality gate

### DIFF
--- a/.github/build-and-test/action.yml
+++ b/.github/build-and-test/action.yml
@@ -1,5 +1,5 @@
 name: Build and run tests
-description: Build the application and run tests in a local environment using Docker
+description: Build the application and run tests in a local environment
 
 runs:
   using: 'composite'

--- a/.github/build-and-test/action.yml
+++ b/.github/build-and-test/action.yml
@@ -1,4 +1,5 @@
 name: Build and run tests
+description: Build the application and run tests in a local environment using Docker
 
 runs:
   using: 'composite'
@@ -26,3 +27,15 @@ runs:
         SPRING_PROFILES_ACTIVE: test
       shell:
         bash
+
+    - name: Generate JaCoCo Report
+      run: mvn jacoco:report
+      env:
+        SPRING_PROFILES_ACTIVE: test
+      shell: bash
+
+    - name: Upload JaCoCo Report
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: jacoco-report
+        path: target/site/jacoco

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
                 <executions>
-                    <!-- Prepare agent for unit tests -->
+                    <!-- Prepare runtime agent for unit tests -->
                     <execution>
                         <goals>
                             <goal>prepare-agent</goal>
@@ -268,11 +268,7 @@
                             <rules>
                                 <!-- Line coverage minimum: fail build if below threshold -->
                                 <rule>
-                                    <element>PACKAGE</element>
-                                    <excludes>
-                                        <exclude>uk.gov.laa.gpfd.config</exclude>
-                                        <exclude>uk.gov.laa.gpfd.exception</exclude>
-                                    </excludes>
+                                    <element>BUNDLE</element>
                                     <limits>
                                         <limit>
                                             <counter>LINE</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <!-- Code coverage thresholds: fail build if coverage falls below these values -->
+        <coverage.line.minimum>0.80</coverage.line.minimum>
+        <coverage.branch.minimum>0.68</coverage.branch.minimum>
     </properties>
 
     <build>
@@ -232,6 +236,60 @@
                     <attachClasses>true</attachClasses>
                     <classesClassifier>classes</classesClassifier>
                 </configuration>
+            </plugin>
+            <!-- JaCoCo for code coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <!-- Prepare agent for unit tests -->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Generate coverage report after tests -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- Check coverage against minimum thresholds -->
+                    <execution>
+                        <id>coverage-check</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- Line coverage minimum: fail build if below threshold -->
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <excludes>
+                                        <exclude>uk.gov.laa.gpfd.config</exclude>
+                                        <exclude>uk.gov.laa.gpfd.exception</exclude>
+                                    </excludes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${coverage.line.minimum}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${coverage.branch.minimum}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
-        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <!-- Code coverage thresholds: fail build if coverage falls below these values -->
         <coverage.line.minimum>0.80</coverage.line.minimum>
         <coverage.branch.minimum>0.68</coverage.branch.minimum>


### PR DESCRIPTION
JIRA: [1379](https://dsdmoj.atlassian.net/browse/LPF-1379)

## Description of changes
Add JaCoCo, coverage threshold and quality gate. Thresholds were chosen as current coverage values.

In JaCoCo configuration we choose bundle over package because we want to cover the whole project rather than setting a minimum target for specific packages and then define exceptions to the rule. We could review this later on if we feel like to focus tests on a specific area. 

JaCoCo doesn't provide a summary during the build & test phase so we modified the github action workflow to add the coverage report as an downloadable zip artifact.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful [deployment](url)
Current code coverage stats are: 
<img width="1179" height="598" alt="image" src="https://github.com/user-attachments/assets/0a2855c9-489e-4008-b0f5-7af515b4d032" />

## Checklist
- [x] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [x] Clean commit history