### PR TITLE
LPF-1364: Harden security headers

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 
     private final AuthorizationManager<RequestAuthorizationContext> authManager;
     private final HttpSecuritySessionManagementConfigurerBuilder concurrencyControlConfigurerCustomizer;
-    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    @Value("${gpfd.security.cors.allowed-origin}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 
     private final AuthorizationManager<RequestAuthorizationContext> authManager;
     private final HttpSecuritySessionManagementConfigurerBuilder concurrencyControlConfigurerCustomizer;
-    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8080}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -46,6 +47,33 @@ public class SecurityConfig {
     private String allowedCorsOrigin;
 
     /**
+     * Configures a dedicated security filter chain for static assets.
+     *
+     * <p>
+     * Static resources such as CSS, JavaScript, images, MoJ and GOV.UK frontend assets
+     * are served through a separate higher-priority filter chain to avoid inheriting
+     * the cache-control headers used for authenticated application responses.
+     * </p>
+     *
+     * <p>
+     * This separation allows browsers to cache static assets efficiently while
+     * preserving strict no-store policies for sensitive authenticated content.
+     * </p>
+     *
+     * @param http the {@link HttpSecurity} object used to configure security for static resources
+     * @return a configured {@link SecurityFilterChain} for static resource requests
+     * @throws Exception if an error occurs while building the security filter chain
+     */
+    @Bean
+    @Order(1)
+    SecurityFilterChain staticChain(HttpSecurity http) throws Exception {
+        http.securityMatcher("/govuk/**", "/moj/**", "/css/**", "/js/**", "/images/**")
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .headers(HeadersConfigurer::disable);
+        return http.build();
+    }
+
+    /**
      * Configures the {@link SecurityFilterChain} for the HTTP security settings.
      * <p>
      * This method customizes the security filter chain by applying the authorization
@@ -53,6 +81,8 @@ public class SecurityConfig {
      * configuration to control session concurrency and expiration.
      * We create the customisers in the function as Bean customisers are automatically implemented by Spring Security 7,
      * and running each customiser twice can cause issues.
+     * Static resources are configured using a separate filter chain to ensure
+     * asset caching remains independent from authenticated response cache policies.
      * </p>
      *
      * @param httpSecurity the {@link HttpSecurity} object used to configure HTTP security.
@@ -78,8 +108,7 @@ public class SecurityConfig {
                                 .includeSubDomains(true)
                                 .preload(true)
                         )
-                        .contentTypeOptions(contentTypeOptions -> {
-                        })
+                        .contentTypeOptions(Customizer.withDefaults())
                         .referrerPolicy(referrerPolicy -> referrerPolicy
                                 .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)
                         ).permissionsPolicyHeader(permissionsPolicy -> permissionsPolicy

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -2,18 +2,27 @@ package uk.gov.laa.gpfd.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import uk.gov.laa.gpfd.config.builders.AuthorizeHttpRequestsBuilder;
 import uk.gov.laa.gpfd.config.builders.HttpSecuritySessionManagementConfigurerBuilder;
 import uk.gov.laa.gpfd.config.builders.SessionManagementConfigurerBuilder;
 
 import static com.azure.spring.cloud.autoconfigure.implementation.aad.security.AadWebApplicationHttpSecurityConfigurer.aadWebApplication;
+import java.util.List;
 
 /**
  * Configuration class to set up Spring Security for the application.
@@ -33,6 +42,8 @@ public class SecurityConfig {
 
     private final AuthorizationManager<RequestAuthorizationContext> authManager;
     private final HttpSecuritySessionManagementConfigurerBuilder concurrencyControlConfigurerCustomizer;
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    private String allowedCorsOrigin;
 
     /**
      * Configures the {@link SecurityFilterChain} for the HTTP security settings.
@@ -58,9 +69,25 @@ public class SecurityConfig {
                         PathPatternRequestMatcher.withDefaults().matcher("/csp-report")
                 ))
                 .with(aadWebApplication())
+                .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorizeHttpRequestsBuilder)    // Apply authorization rules
                 .sessionManagement(sessionManagementConfigurerBuilder)  // Apply session management configuration
                 .headers(headers -> headers
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .maxAgeInSeconds(63072000)
+                                .includeSubDomains(true)
+                                .preload(true)
+                        )
+                        .contentTypeOptions(contentTypeOptions -> {
+                        })
+                        .referrerPolicy(referrerPolicy -> referrerPolicy
+                                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)
+                        ).permissionsPolicyHeader(permissionsPolicy -> permissionsPolicy
+                                .policy("interest-cohort=()")
+                        )
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::deny)
+                        .addHeaderWriter(new StaticHeadersWriter("Cache-Control", "no-store"))
+                        .addHeaderWriter(new StaticHeadersWriter("Pragma", "no-cache"))
                         .contentSecurityPolicy(csp -> csp
                                 .policyDirectives(
                                         "default-src 'none'; " +
@@ -79,6 +106,17 @@ public class SecurityConfig {
                         )
                 )
                 .build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(allowedCorsOrigin));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
 }

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 
     private final AuthorizationManager<RequestAuthorizationContext> authManager;
     private final HttpSecuritySessionManagementConfigurerBuilder concurrencyControlConfigurerCustomizer;
-    @Value("${gpfd.security.cors.allowed-origin}")
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -43,11 +44,40 @@ public class SecurityConfigLocal {
     private String allowedCorsOrigin;
 
     /**
+     * Configures a dedicated security filter chain for static assets.
+     *
+     * <p>
+     * Static resources such as CSS, JavaScript, images, MoJ and GOV.UK frontend assets
+     * are served through a separate higher-priority filter chain to avoid inheriting
+     * the cache-control headers used for authenticated application responses.
+     * </p>
+     *
+     * <p>
+     * This separation allows browsers to cache static assets efficiently while
+     * preserving strict no-store policies for sensitive authenticated content.
+     * </p>
+     *
+     * @param http the {@link HttpSecurity} object used to configure security for static resources
+     * @return a configured {@link SecurityFilterChain} for static resource requests
+     * @throws Exception if an error occurs while building the security filter chain
+     */
+    @Bean
+    @Order(1)
+    SecurityFilterChain staticChain(HttpSecurity http) throws Exception {
+        http.securityMatcher("/govuk/**", "/moj/**", "/css/**", "/js/**", "/images/**")
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .headers(HeadersConfigurer::disable);
+        return http.build();
+    }
+
+    /**
      * Configures the {@link SecurityFilterChain} for the HTTP security settings.
      * <p>
      * This method customizes the security filter chain by applying the authorization
      * rules, enabling HTTP basic authentication, and applying the session management
      * configuration to control session concurrency and expiration.
+     * Static resources are configured using a separate filter chain to ensure
+     * asset caching remains independent from authenticated response cache policies.
      * </p>
      *
      * @param httpSecurity the {@link HttpSecurity} object used to configure HTTP security.

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
@@ -39,7 +39,7 @@ import java.util.List;
 @Configuration
 @ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "false")
 public class SecurityConfigLocal {
-    @Value("${gpfd.security.cors.allowed-origin}")
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
@@ -40,7 +40,7 @@ import java.util.List;
 @Configuration
 @ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "false")
 public class SecurityConfigLocal {
-    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8080}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
@@ -39,7 +39,7 @@ import java.util.List;
 @Configuration
 @ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "false")
 public class SecurityConfigLocal {
-    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    @Value("${gpfd.security.cors.allowed-origin}")
     private String allowedCorsOrigin;
 
     /**

--- a/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/SecurityConfigLocal.java
@@ -1,17 +1,24 @@
 package uk.gov.laa.gpfd.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import uk.gov.laa.gpfd.config.builders.AuthorizeHttpRequestsBuilder;
 import uk.gov.laa.gpfd.config.builders.SessionManagementConfigurerBuilder;
 
@@ -32,6 +39,8 @@ import java.util.List;
 @Configuration
 @ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "false")
 public class SecurityConfigLocal {
+    @Value("${gpfd.security.cors.allowed-origin:https://127.0.0.1:8020}")
+    private String allowedCorsOrigin;
 
     /**
      * Configures the {@link SecurityFilterChain} for the HTTP security settings.
@@ -53,9 +62,24 @@ public class SecurityConfigLocal {
                         PathPatternRequestMatcher.withDefaults().matcher("/h2-console/**"),
                         PathPatternRequestMatcher.withDefaults().matcher("/csp-report")
                 ))
+                .cors(Customizer.withDefaults())
                 // Allow h2-console to display in web-frames
                 .headers(headers -> headers
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .maxAgeInSeconds(63072000)
+                                .includeSubDomains(true)
+                                .preload(true)
+                        )
+                        .contentTypeOptions(contentTypeOptions -> {
+                        })
+                        .referrerPolicy(referrerPolicy -> referrerPolicy
+                                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)
+                        ).permissionsPolicyHeader(permissionsPolicy -> permissionsPolicy
+                                .policy("interest-cohort=()")
+                        )
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+                        .addHeaderWriter(new StaticHeadersWriter("Cache-Control", "no-store"))
+                        .addHeaderWriter(new StaticHeadersWriter("Pragma", "no-cache"))
                         .contentSecurityPolicy(csp -> csp
                                 .policyDirectives(
                                         "default-src 'none'; " +
@@ -76,6 +100,17 @@ public class SecurityConfigLocal {
                 )
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(allowedCorsOrigin));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,6 +3,9 @@ gpfd:
   # baseUrl is a Spring Security template that resolves based on the current URL
   redirect-uri-template: "{baseUrl}/login/oauth2/code/gpfd-azure-dev"
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
+  security:
+    cors:
+      allowed-origin: https://dev-laa-get-payments-finance-data.cloud-platform.service.justice.gov.uk
 
   # DEV MOJFIN database config
   datasource:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,9 @@ logging:
 gpfd:
   url: http://localhost:8080
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-dev
+  security:
+    cors:
+      allowed-origin: https://localhost:8080
 
   datasource:
     read-only:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ gpfd:
   redirect-uri-template: ${gpfd.url}/login/oauth2/code/gpfd-azure-dev
   security:
     cors:
-      allowed-origin: https://localhost:8080
+      allowed-origin: http://localhost:8080
 
   datasource:
     read-only:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,6 +3,9 @@ gpfd:
   # baseUrl is a Spring Security template that resolves based on the current URL
   redirect-uri-template: "{baseUrl}/login/oauth2/code/gpfd-azure-prod"
   # Note,"gpfd-azure-prod" is also known as the Oauth2 'registrationId'
+  security:
+    cors:
+      allowed-origin: https://get-legal-aid-data.service.justice.gov.uk
 
   # MOJFIN database config
   datasource:

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -3,6 +3,9 @@ gpfd:
   # baseUrl is a Spring Security template that resolves based on the current URL
   redirect-uri-template: "{baseUrl}/login/oauth2/code/gpfd-azure-uat"
   # Note,"gpfd-azure-uat" is also known as the Oauth2 'registrationId'
+  security:
+    cors:
+      allowed-origin: https://uat-laa-get-payments-finance-data.cloud-platform.service.justice.gov.uk
 
   # MOJFIN database config
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,6 @@ gpfd:
     has-s3-access: false
   csv-generation:
     buffer-flush-frequency: 5000
+  security:
+    cors:
+      allowed-origin: https://127.0.0.1:8020

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,3 @@ gpfd:
     has-s3-access: false
   csv-generation:
     buffer-flush-frequency: 5000
-  security:
-    cors:
-      allowed-origin: https://127.0.0.1:8020

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,4 +40,4 @@ gpfd:
     buffer-flush-frequency: 5000
   security:
     cors:
-      allowed-origin: https://127.0.0.1:8020
+      allowed-origin: https://127.0.0.1:8080

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,6 +3,9 @@ gpfd:
   redirect-uri-template: http://localhost:8080
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
+  security:
+    cors:
+      allowed-origin: https://localhost:8080
   datasource:
     read-only:
       url: jdbc:h2:mem:MOJFINTest;DB_CLOSE_DELAY=-1;MODE=Oracle

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ gpfd:
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
   security:
     cors:
-      allowed-origin: https://localhost:8080
+      allowed-origin: http://localhost:8080
   datasource:
     read-only:
       url: jdbc:h2:mem:MOJFINTest;DB_CLOSE_DELAY=-1;MODE=Oracle

--- a/src/test/resources/application-testauth.yml
+++ b/src/test/resources/application-testauth.yml
@@ -3,6 +3,9 @@ gpfd:
   redirect-uri-template: http://localhost:8080
   # Note,"gpfd-azure-dev" is also known as the Oauth2 'registrationId'
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
+  security:
+    cors:
+      allowed-origin: https://localhost:8080
   datasource:
     read-only:
       url: jdbc:h2:mem:MOJFINTestAuth;DB_CLOSE_DELAY=-1;MODE=Oracle

--- a/src/test/resources/application-testauth.yml
+++ b/src/test/resources/application-testauth.yml
@@ -5,7 +5,7 @@ gpfd:
   # DEV MOJFIN database config. Test SQL will be written in vanilla ANSI SQL, as H2 still has issues with Oracle syntax - despite the mode being set to oracle
   security:
     cors:
-      allowed-origin: https://localhost:8080
+      allowed-origin: http://localhost:8080
   datasource:
     read-only:
       url: jdbc:h2:mem:MOJFINTestAuth;DB_CLOSE_DELAY=-1;MODE=Oracle


### PR DESCRIPTION
JIRA: [LPF-1364](https://dsdmoj.atlassian.net/browse/LPF-1364)

## Description of changes
- Added suggested security headers https://dsdmoj.atlassian.net/wiki/spaces/LAACST/pages/5845516326/API+Secure+Pattern+-+Usage+Guide
- updated application yaml files to include cors allowed-origin
- ingress seems to override the max-age to 31536000, not able to force it to use 63072000 as recommended but shouldn't be a major issue anyways

## Evidence
<img width="858" height="296" alt="Screenshot 2026-05-06 at 14 51 12" src="https://github.com/user-attachments/assets/08b7a8b8-93c9-4836-b7e9-d64e5d88485c" />

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history

[LPF-1364]: https://dsdmoj.atlassian.net/browse/LPF-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ