### PR TITLE
LPF-1384 - Code scanning tool fix - dual licensing issue

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -15,14 +15,14 @@ ignore:
           production.
         expires: 2026-09-01T09:00:00.000Z
         created: 2026-05-06T16:30:00.000Z
-"snyk:lic:maven:ch.qos.logback:logback-core:(EPL-1.0_OR_LGPL-2.1)"
+"snyk:lic:maven:ch.qos.logback:logback-core:(EPL-1.0_OR_LGPL-2.1)":
     - '*':
         reason: >
           License is weak copyleft (EPL-1.0 and LGPL-2.1). Service is not distributed.
           Replacement would be disproportionate effort.
         expires: 2026-09-01T09:00:00.000Z
         created: 2026-05-06T16:30:00.000Z
-"snyk:lic:maven:ch.qos.logback:logback-classic:(EPL-1.0_OR_LGPL-2.1)"
+"snyk:lic:maven:ch.qos.logback:logback-classic:(EPL-1.0_OR_LGPL-2.1)":
     - '*':
         reason: >
           Logback is pulled in transitively by Spring Boot. License is weak

--- a/.snyk
+++ b/.snyk
@@ -8,4 +8,25 @@ ignore:
              Transitive from Spring 4. Will wait for updates to bring in version bump
           expires: 2026-05-14T00:00:00.000Z
           created: 2026-04-14T00:00:00.000Z
+"snyk:lic:maven:com.h2database:h2:(EPL-1.0_OR_MPL-2.0)":
+    - '*':
+        reason: >
+          H2 is used only for development and testing, not distributed in
+          production.
+        expires: 2026-09-01T09:00:00.000Z
+        created: 2026-05-06T16:30:00.000Z
+"snyk:lic:maven:ch.qos.logback:logback-core:(EPL-1.0_OR_LGPL-2.1)"
+    - '*':
+        reason: >
+          License is weak copyleft (EPL-1.0 and LGPL-2.1). Service is not distributed.
+          Replacement would be disproportionate effort.
+        expires: 2026-09-01T09:00:00.000Z
+        created: 2026-05-06T16:30:00.000Z
+"snyk:lic:maven:ch.qos.logback:logback-classic:(EPL-1.0_OR_LGPL-2.1)"
+    - '*':
+        reason: >
+          Logback is pulled in transitively by Spring Boot. License is weak
+          copyleft (EPL-1.0 and LGPL-2.1). Service is not distributed. Replacement would be disproportionate effort.
+        expires: 2026-09-01T09:00:00.000Z
+        created: 2026-05-06T16:30:00.000Z
 patch: {}


### PR DESCRIPTION
JIRA: [LPF-1384](https://dsdmoj.atlassian.net/browse/LPF-13384)

## Description of changes
Fixing CodeQL scanner issues:
- Put snyk ignore rules in place for licenising issues


## Checklist
- [X] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1384]: https://dsdmoj.atlassian.net/browse/LPF-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ