### PR TITLE
LPF-1384 - CodeQL issue fix tomcat embed vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,4 +8,32 @@ ignore:
              Transitive from Spring 4. Will wait for updates to bring in version bump
           expires: 2026-05-14T00:00:00.000Z
           created: 2026-04-14T00:00:00.000Z
+  SNYK-JAVA-IONETTY-16438323:
+        - '*':
+            reason: >-
+                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
+                 We will monitor this vulnerability and update the version when it is fixed.
+            expires: 2026-06-07T12:00:00.000Z
+            created: 2026-05-07T11:30:00.000Z
+  SNYK-JAVA-IONETTY-16438931:
+        - '*':
+            reason: >-
+                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
+                 We will monitor this vulnerability and update the version when it is fixed.
+            expires: 2026-06-07T12:00:00.000Z
+            created: 2026-05-07T11:30:00.000Z
+  SNYK-JAVA-IONETTY-16438936:
+        - '*':
+            reason: >-
+                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
+                 We will monitor this vulnerability and update the version when it is fixed.
+            expires: 2026-06-07T12:00:00.000Z
+            created: 2026-05-07T11:30:00.000Z
+  SNYK-JAVA-IONETTY-16438938:
+        - '*':
+            reason: >-
+                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
+                 We will monitor this vulnerability and update the version when it is fixed.
+            expires: 2026-06-07T12:00:00.000Z
+            created: 2026-05-07T11:30:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -8,32 +8,4 @@ ignore:
              Transitive from Spring 4. Will wait for updates to bring in version bump
           expires: 2026-05-14T00:00:00.000Z
           created: 2026-04-14T00:00:00.000Z
-  SNYK-JAVA-IONETTY-16438323:
-        - '*':
-            reason: >-
-                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
-                 We will monitor this vulnerability and update the version when it is fixed.
-            expires: 2026-06-07T12:00:00.000Z
-            created: 2026-05-07T11:30:00.000Z
-  SNYK-JAVA-IONETTY-16438931:
-        - '*':
-            reason: >-
-                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
-                 We will monitor this vulnerability and update the version when it is fixed.
-            expires: 2026-06-07T12:00:00.000Z
-            created: 2026-05-07T11:30:00.000Z
-  SNYK-JAVA-IONETTY-16438936:
-        - '*':
-            reason: >-
-                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
-                 We will monitor this vulnerability and update the version when it is fixed.
-            expires: 2026-06-07T12:00:00.000Z
-            created: 2026-05-07T11:30:00.000Z
-  SNYK-JAVA-IONETTY-16438938:
-        - '*':
-            reason: >-
-                 Discovered on 7th May 2026. Despite Snyk claiming it has been fixed in 4.2.13.Final, it has not.
-                 We will monitor this vulnerability and update the version when it is fixed.
-            expires: 2026-06-07T12:00:00.000Z
-            created: 2026-05-07T11:30:00.000Z
 patch: {}

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.18</version>
+                <version>11.0.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -459,7 +459,11 @@
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,11 @@
             <artifactId>netty-codec-http2</artifactId>
             <version>4.2.13.Final</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http3</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,12 @@
                 <artifactId>thymeleaf-spring6</artifactId>
                 <version>3.1.5.RELEASE</version>
             </dependency>
+            <!-- Overriding webmvc version until it is fixed in 4.0.x -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>11.0.18</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,24 @@
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--   Pulling in below Netty dependencies to
+        resolve vulnerabilities raised by Snyk   -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-compression</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -459,11 +459,6 @@
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.13.Final</version>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,11 @@
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
JIRA: [LPF-1384](https://dsdmoj.atlassian.net/browse/LPF-1384)

## Description of changes
CodeQL fix for Tomcat Embed vulnerability and Netty related vulns (see below).

- Fixes: 
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/124
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/242
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/243
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/244
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/245
   
- Fixed tomcat embed with an override until a patch for spring is released.

## Checklist
- [X] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [X] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1384]: https://dsdmoj.atlassian.net/browse/LPF-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ