### PR TITLE
LPF-1189 - handle no roles supplied from SiLAS better

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/exception/UnableToParseAuthDetailsException.java
+++ b/src/main/java/uk/gov/laa/gpfd/exception/UnableToParseAuthDetailsException.java
@@ -70,4 +70,44 @@ public abstract sealed class UnableToParseAuthDetailsException extends RuntimeEx
         }
     }
 
+    /**
+     * Exception throw when we can't get attributes out of the auth token sent via SiLAS.
+     */
+    public static final class NoAttributesOnTokenException extends UnableToParseAuthDetailsException {
+
+        /**
+         * Constructs a new {@code NoAttributesOnTokenException}.
+         */
+        public NoAttributesOnTokenException() {
+            super("Could not parse attributes from token");
+        }
+    }
+
+    /**
+     * Exception throw when user has no roles returned in the token.
+     * This isn't really a valid setup in SiLAS so it suggests SiLAS isn't sending us the roles.
+     */
+    public static final class NoRolesInAttributeException extends UnableToParseAuthDetailsException {
+
+        /**
+         * Constructs a new {@code NoRolesException}.
+         */
+        public NoRolesInAttributeException() {
+            super("No roles were sent in the token");
+        }
+    }
+
+    /**
+     * Exception throw when roles returned in the token but there are none.
+     */
+    public static final class NoRolesException extends UnableToParseAuthDetailsException {
+
+        /**
+         * Constructs a new {@code NoRolesException}.
+         */
+        public NoRolesException() {
+            super("No roles are assigned to the user");
+        }
+    }
+
 }

--- a/src/main/java/uk/gov/laa/gpfd/exception/UnableToParseAuthDetailsException.java
+++ b/src/main/java/uk/gov/laa/gpfd/exception/UnableToParseAuthDetailsException.java
@@ -98,7 +98,7 @@ public abstract sealed class UnableToParseAuthDetailsException extends RuntimeEx
     }
 
     /**
-     * Exception throw when roles returned in the token but there are none.
+     * Exception throw when roles key is returned in the token attributes but the user has none assigned.
      */
     public static final class NoRolesException extends UnableToParseAuthDetailsException {
 

--- a/src/main/java/uk/gov/laa/gpfd/utils/SecurityUtils.java
+++ b/src/main/java/uk/gov/laa/gpfd/utils/SecurityUtils.java
@@ -6,7 +6,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.AuthenticationIsNullException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoAttributesOnTokenException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoOidSetOnTokenException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesInAttributeException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.PrincipalIsNullException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.UnexpectedAuthClassException;
 
@@ -34,24 +37,33 @@ public class SecurityUtils {
      */
     public List<String> extractRoles() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!(auth != null && auth.getPrincipal() instanceof OidcUser oidcUser)) {
-            log.info("No odicUser");
-            return List.of();
-        }
-        log.info("Got oidcUser");
-
-        Map<String, Object> attributes = oidcUser.getAttributes();
-        if (attributes == null) {
-            log.info("No attributes");
-            return List.of();
+        if (auth == null) {
+            throw new AuthenticationIsNullException();
         }
 
-        log.info("Got attributes");
+        return switch (auth.getPrincipal()) {
+            case OidcUser oidcUser -> {
 
-        log.info("Is the role claim in there? " + attributes.containsKey(ROLE_CLAIM));
-        Object rawRoles = attributes.get(ROLE_CLAIM);
-        log.info("Raw roles are " + rawRoles);
-        return parseRoles(rawRoles);
+                Map<String, Object> attributes = oidcUser.getAttributes();
+                if (attributes == null) {
+                    throw new NoAttributesOnTokenException();
+                }
+
+                if (!attributes.containsKey(ROLE_CLAIM)) {
+                    throw new NoRolesInAttributeException();
+                }
+
+                Object rawRoles = attributes.get(ROLE_CLAIM);
+                List<String> parsedRoles = parseRoles(rawRoles);
+                if (parsedRoles.isEmpty()) {
+                    throw new NoRolesException();
+                }
+                yield parsedRoles;
+            }
+            case null -> throw new PrincipalIsNullException();
+            default -> throw new UnexpectedAuthClassException("Unexpected Auth Type: " + auth.getClass().getName());
+        };
+
     }
 
     /**

--- a/src/test/java/uk/gov/laa/gpfd/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/controller/GlobalExceptionHandlerTest.java
@@ -14,7 +14,10 @@ import uk.gov.laa.gpfd.exception.CsvGenerationException.MetadataInvalidException
 import uk.gov.laa.gpfd.exception.FileDownloadException.InvalidDownloadFormatException;
 import uk.gov.laa.gpfd.exception.FileDownloadException.ReportNotSupportedForDownloadException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.AuthenticationIsNullException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoAttributesOnTokenException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoOidSetOnTokenException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesInAttributeException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.PrincipalIsNullException;
 import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.UnexpectedAuthClassException;
 import uk.gov.laa.gpfd.exception.FileDownloadException.S3BucketHasNoCopiesOfReportException;
@@ -362,7 +365,10 @@ class GlobalExceptionHandlerTest {
                 new AuthenticationIsNullException(),
                 new PrincipalIsNullException(),
                 new UnexpectedAuthClassException("UserJwt"),
-                new NoOidSetOnTokenException()
+                new NoOidSetOnTokenException(),
+                new NoRolesException(),
+                new NoRolesInAttributeException(),
+                new NoAttributesOnTokenException()
         );
     }
 

--- a/src/test/java/uk/gov/laa/gpfd/utils/SecurityUtilsTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/utils/SecurityUtilsTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
@@ -11,12 +13,21 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.AuthenticationIsNullException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoAttributesOnTokenException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoOidSetOnTokenException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.NoRolesInAttributeException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.PrincipalIsNullException;
+import uk.gov.laa.gpfd.exception.UnableToParseAuthDetailsException.UnexpectedAuthClassException;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,25 +61,31 @@ class SecurityUtilsTest {
     }
 
     @Test
-    void extractRoles_returnsEmptyList_whenNoAuthentication() {
+    void extractRoles_throwsException_whenNoAuthentication() {
         SecurityContextHolder.clearContext();
-
-        List<String> roles = securityUtils.extractRoles();
-
-        assertTrue(roles.isEmpty());
+        assertThrows(AuthenticationIsNullException.class, securityUtils::extractRoles);
     }
 
     @Test
-    void extractRoles_returnsEmptyList_whenPrincipalIsNotOidcUser() {
+    void extractRoles_throwsException_whenPrincipalIsNotOidcUser() {
         Authentication auth = mock(Authentication.class);
         when(auth.getPrincipal()).thenReturn("not-an-oidc-user");
 
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        List<String> roles = securityUtils.extractRoles();
-
-        assertTrue(roles.isEmpty());
+        assertThrows(UnexpectedAuthClassException.class, securityUtils::extractRoles);
     }
+
+    @Test
+    void extractRoles_throwsException_whenPrincipalIsNull() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(null);
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThrows(PrincipalIsNullException.class, securityUtils::extractRoles);
+    }
+
 
     @Test
     void extractRoles_parsesListOfRolesCorrectly() {
@@ -95,14 +112,52 @@ class SecurityUtilsTest {
     }
 
     @Test
-    void extractRoles_returnsEmptyList_whenNull() {
+    void extractRoles_throwsException_whenAttributesAreNull() {
         when(authentication.getPrincipal()).thenReturn(oidcUser);
         when(oidcUser.getAttributes()).thenReturn(null);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        List<String> roles = securityUtils.extractRoles();
-        assertTrue(roles.isEmpty());
+        assertThrows(NoAttributesOnTokenException.class, securityUtils::extractRoles);
     }
+
+    @Test
+    void extractRoles_throwsException_whenAttributesDoNotContainLAARoles() {
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+        when(oidcUser.getAttributes()).thenReturn(Map.of("stuff", "things", "otherEntry", "differentthings,inhere"));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertThrows(NoRolesInAttributeException.class, securityUtils::extractRoles);
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyRoleProvider")
+    void extractRoles_throwsException_whenRoleSuppliedIsEmpty(Object emptyRole) {
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+        Map<String, Object> emptyRoleMap = new HashMap<>();
+        emptyRoleMap.put("LAA_APP_ROLES", emptyRole);
+        when(oidcUser.getAttributes()).thenReturn(emptyRoleMap);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertThrows(NoRolesException.class, securityUtils::extractRoles);
+    }
+
+    private static Stream<Object> emptyRoleProvider() {
+        return of(
+                List.of(),
+                "",
+                null
+        );
+    }
+
+    @Test
+    void extractRoles_throwsException_whenRoleSuppliedIsEmptyStringList() {
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+        when(oidcUser.getAttributes()).thenReturn(Map.of("LAA_APP_ROLES", ""));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertThrows(NoRolesException.class, securityUtils::extractRoles);
+    }
+
 
     @Test
     void isAuthorized_returnsTrue_whenUserHasAtLeastOneRequiredRole() {
@@ -132,7 +187,7 @@ class SecurityUtilsTest {
     @Test
     void extractUserId_throwsExceptionIfAuthIsNull() {
         SecurityContextHolder.clearContext();
-        assertThrows(UnableToParseAuthDetailsException.AuthenticationIsNullException.class, securityUtils::extractUserId);
+        assertThrows(AuthenticationIsNullException.class, securityUtils::extractUserId);
     }
 
     @Test
@@ -140,7 +195,7 @@ class SecurityUtilsTest {
         when(authentication.getPrincipal()).thenReturn(null);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        assertThrows(UnableToParseAuthDetailsException.PrincipalIsNullException.class, securityUtils::extractUserId);
+        assertThrows(PrincipalIsNullException.class, securityUtils::extractUserId);
     }
 
     @Test
@@ -150,7 +205,16 @@ class SecurityUtilsTest {
         when(authenticationWrongType.getPrincipal()).thenReturn(principal);
         SecurityContextHolder.getContext().setAuthentication(authenticationWrongType);
 
-        assertThrows(UnableToParseAuthDetailsException.UnexpectedAuthClassException.class, securityUtils::extractUserId);
+        assertThrows(UnexpectedAuthClassException.class, securityUtils::extractUserId);
+    }
+
+    @Test
+    void extractUserId_throwsExceptionIfNoOidSet() {
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+        when(oidcUser.getAttribute("oid")).thenReturn(null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertThrows(NoOidSetOnTokenException.class, securityUtils::extractUserId);
     }
 
 }


### PR DESCRIPTION
JIRA: [LPF-1189](https://dsdmoj.atlassian.net/browse/LPF-1189)

## Description of changes
- Currently in the SILAS feature branch, when we get sent no roles from SiLAS (be that due to user or app setup issues), we try and make a database call to fetch all reports available to a user with no roles
- This throws a database exception as it tries to bind empty list to the database request
- There is no valid scenario where a user has no roles. When setting up a user on SiLAS to use GLAD, you **must** give them at least one role. As such we should error straight away if we parse a user's auth and find no roles inside.
## Evidence

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history

[LPF-1189]: https://dsdmoj.atlassian.net/browse/LPF-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ