### PR TITLE
LPF-1384 - CodeQL fix: log injection issue 

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/RequestResponseInterceptor.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/RequestResponseInterceptor.java
@@ -3,6 +3,8 @@ package uk.gov.laa.gpfd.config;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.spi.LoggingEventBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -12,35 +14,66 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class RequestResponseInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (handler instanceof HandlerMethod handlerMethod) {
-            log.info("Request received: {} {} ({})",
-                    request.getMethod(),
-                    request.getRequestURI(),
-                    handlerMethod.getMethod().getName());
-        } else {
-            log.info("Request received: {} {}",
-                    request.getMethod(),
-                    request.getRequestURI());
-        }
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) {
+        logRequest(request, handler);
         return true;
     }
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        if (handler instanceof HandlerMethod handlerMethod) {
-            log.info("Completed request: {} with status {} ({})",
-                    request.getRequestURI(),
-                    response.getStatus(),
-                    handlerMethod.getMethod().getName());
-        } else {
-            log.info("Completed request: {} with status {}",
-                    request.getRequestURI(),
-                    response.getStatus());
-        }
+    public void afterCompletion(@NonNull HttpServletRequest request,
+                                @NonNull HttpServletResponse response,
+                                @NonNull Object handler,
+                                Exception ex) {
+
+        logResponse(request, response, handler);
 
         if (ex != null) {
-            log.error("Exception occurred", ex);
+            log.atError().setCause(ex).log("Exception occurred");
         }
+    }
+
+    private void logRequest(HttpServletRequest request, Object handler) {
+
+        LoggingEventBuilder logBuilder = log.atInfo()
+                .addKeyValue("method", sanitise(request.getMethod()))
+                .addKeyValue("uri", sanitise(request.getRequestURI()));
+
+        addHandler(logBuilder, handler);
+
+        logBuilder.log("Request received");
+    }
+
+    private void logResponse(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+
+        LoggingEventBuilder logBuilder = log.atInfo()
+                .addKeyValue("uri", sanitise(request.getRequestURI()))
+                .addKeyValue("status", response.getStatus());
+
+        addHandler(logBuilder, handler);
+
+        logBuilder.log("Completed request");
+    }
+
+    private void addHandler(LoggingEventBuilder logBuilder, Object handler) {
+
+        if (handler instanceof HandlerMethod handlerMethod) {
+            logBuilder.addKeyValue(
+                    "handler",
+                    handlerMethod.getMethod().getName()
+            );
+        }
+    }
+
+    private String sanitise(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        // Prevent CRLF / log forging attacks
+        return value.replaceAll("\\p{Cntrl}", "_");
     }
 }

--- a/src/main/java/uk/gov/laa/gpfd/config/RequestResponseInterceptor.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/RequestResponseInterceptor.java
@@ -68,7 +68,7 @@ public class RequestResponseInterceptor implements HandlerInterceptor {
         }
     }
 
-    private String sanitise(String value) {
+    String sanitise(String value) {
         if (value == null) {
             return null;
         }

--- a/src/test/java/uk/gov/laa/gpfd/config/RequestResponseInterceptorTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/RequestResponseInterceptorTest.java
@@ -1,0 +1,81 @@
+package uk.gov.laa.gpfd.config;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.classic.Logger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class RequestResponseInterceptorTest {
+    @Test
+    void shouldSanitiseControlCharacters() {
+
+        RequestResponseInterceptor interceptor =
+                new RequestResponseInterceptor();
+
+        String sanitized =
+                interceptor.sanitise("/reports/\r\nFAKE");
+
+        assertEquals("/reports/__FAKE", sanitized);
+    }
+
+    @Test
+    void shouldNotThrowWhenUriContainsControlCharacters() {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI())
+                .thenReturn("/reports/\r\nFORGED");
+
+        RequestResponseInterceptor interceptor =
+                new RequestResponseInterceptor();
+
+        assertDoesNotThrow(() ->
+                interceptor.preHandle(request, response, new Object()));
+    }
+
+    @Test
+    void shouldLogSanitizedUri() {
+
+        Logger logger =
+                (Logger) LoggerFactory.getLogger(RequestResponseInterceptor.class);
+
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+
+        logger.addAppender(appender);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI())
+                .thenReturn("/test/\r\nFORGED");
+
+        RequestResponseInterceptor interceptor =
+                new RequestResponseInterceptor();
+
+        interceptor.preHandle(request, response, new Object());
+
+        String logMessage =
+                appender.list.getFirst().getFormattedMessage();
+
+        assertFalse(logMessage.contains("\r"));
+        assertFalse(logMessage.contains("\n"));
+    }
+}


### PR DESCRIPTION
JIRA: [LPF-1384](https://dsdmoj.atlassian.net/browse/LPF-1384)

## Description of changes
CodeQL raised an issue around log injection, so this PR fixes that issue.
- Fixes: https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/163
- Updated RequestResponseInterceptor.java to remove log injection issue by sanitising the input.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
- [X] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [x] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1384]: https://dsdmoj.atlassian.net/browse/LPF-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ