### PR TITLE
LPF-1384 - CodeQL issues: Netty-http and netty-handler-proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,16 @@
             <artifactId>netty-codec-http3</artifactId>
             <version>4.2.13.Final</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>4.2.13.Final</version>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
JIRA: [LPF-1384](https://dsdmoj.atlassian.net/browse/LPF-1384)

## Description of changes
CodeQL raised issues with the Netty dependency pulling in sub-dependencies that are vulnerable.

- Updated pom file to pull in latest netty-http and handler-proxy versions to remove vulnerability raised by CodeQL. Fixes:
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/238
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/239
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/240
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/241
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/242
    - https://github.com/ministryofjustice/payforlegalaid/security/code-scanning/246


## Checklist
- [x] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [x] Clean commit history

[LPF-1384]: https://dsdmoj.atlassian.net/browse/LPF-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ