### PR TITLE
LPF-1189 - fix bug in ReportSheetDataWriter and add tests

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriter.java
+++ b/src/main/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriter.java
@@ -162,13 +162,15 @@ public final class ReportSheetDataWriter extends SheetDataWriter implements Clos
                         }
                         break;
                     case BOOLEAN:
-                        _out.write("><v>");
+                        // Have tweaked the default Apache POI here as it was placing an extra unopened >
+                        _out.write("<v>");
                         _out.write(cell.getBooleanCellValue() ? "1" : "0");
                         _out.write("</v>");
                         break;
                     case ERROR: {
                         FormulaError error = FormulaError.forInt(cell.getErrorCellValue());
-                        _out.write("><v>");
+                        // Have tweaked the default Apache POI here as it was placing an extra unopened >
+                        _out.write("<v>");
                         outputEscapedString(error.getString());
                         _out.write("</v>");
                         break;

--- a/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
@@ -1,0 +1,302 @@
+package uk.gov.laa.gpfd.services.excel.workbook;
+
+import lombok.SneakyThrows;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.xssf.model.SharedStringsTable;
+import org.apache.poi.xssf.streaming.SheetDataWriter;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.laa.gpfd.model.ReportQuery;
+import uk.gov.laa.gpfd.model.excel.ExcelSheet;
+
+import java.io.StringWriter;
+
+import static org.apache.poi.ss.usermodel.FormulaError.DIV0;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportSheetDataWriterTest {
+
+    @Mock
+    SharedStringsTable sharedStringSource;
+    @Mock
+    ReportQuery report;
+    @Mock
+    StyleManager styleManager;
+    @Mock
+    Cell cell;
+    @Mock
+    ExcelSheet sheet;
+
+
+    ReportSheetDataWriter reportSheetDataWriter;
+
+    StringWriter buffer;
+
+    @SneakyThrows
+    @BeforeEach
+    void beforeEach() {
+        buffer = new StringWriter();
+    }
+
+    @SneakyThrows
+    private void createDataWriter() {
+        createDataWriter(sharedStringSource);
+    }
+
+    @SneakyThrows
+    private void createDataWriter(SharedStringsTable sharedStringSource) {
+        reportSheetDataWriter = new ReportSheetDataWriter(sharedStringSource, report, styleManager);
+        var field = SheetDataWriter.class.getDeclaredField("_out");
+        field.setAccessible(true);
+        field.set(reportSheetDataWriter, buffer);
+    }
+
+    private void setupCommonMocks() {
+        when(report.getExcelSheet()).thenReturn(sheet);
+        when(sheet.getName()).thenReturn("testSheet");
+        when(styleManager.getColumnStyle(anyInt(), any())).thenReturn(-1);
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldDoNothingIfCellNull() {
+        createDataWriter();
+        reportSheetDataWriter.writeCell(1, null);
+
+        assertTrue(buffer.toString().isEmpty());
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteBlankCell() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.BLANK);
+
+        reportSheetDataWriter.writeCell(0, cell);
+
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\"></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteNumericCell() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(123.31);
+
+        reportSheetDataWriter.writeCell(0, cell);
+
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"n\"><v>123.31</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteBooleanCell_withTrueAsOne() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.BOOLEAN);
+        when(cell.getBooleanCellValue()).thenReturn(true);
+
+        reportSheetDataWriter.writeCell(0, cell);
+
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"b\"><v>1</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteBooleanCell_withFalseAsZero() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.BOOLEAN);
+        when(cell.getBooleanCellValue()).thenReturn(false);
+
+        reportSheetDataWriter.writeCell(0, cell);
+
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"b\"><v>0</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_fromSharedStringSource() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        var stringValue = new XSSFRichTextString("string123");
+        when(cell.getRichStringCellValue()).thenReturn(stringValue);
+        when(sharedStringSource.addSharedStringItem(stringValue)).thenReturn(99);
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"s\"><v>99</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource() {
+        createDataWriter(null);
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getStringCellValue()).thenReturn("string123");
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"inlineStr\"><is><t>string123</t></is></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveLeadingSpaces() {
+        createDataWriter(null);
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getStringCellValue()).thenReturn("  string123");
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"inlineStr\"><is><t xml:space=\"preserve\">  string123</t></is></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveTrailingSpaces() {
+        createDataWriter(null);
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getStringCellValue()).thenReturn("string123     ");
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"inlineStr\"><is><t xml:space=\"preserve\">string123     </t></is></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleEmptyString() {
+        createDataWriter(null);
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getStringCellValue()).thenReturn("");
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"inlineStr\"><is><t></t></is></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleNullString() {
+        createDataWriter(null);
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getStringCellValue()).thenReturn(null);
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"inlineStr\"><is><t></t></is></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldWriteErrorCell() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.ERROR);
+        when(cell.getErrorCellValue()).thenReturn(DIV0.getCode());
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"e\"><v>#DIV/0!</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldHandleNumericFormulae() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.NUMERIC);
+        when(cell.getCellFormula()).thenReturn("=A3+B4");
+        when(cell.getNumericCellValue()).thenReturn(1234.32);
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"n\"><f>=A3+B4</f><v>1234.32</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldHandleStringFormulae() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.STRING);
+        when(cell.getCellFormula()).thenReturn("=A3+B4");
+        when(cell.getStringCellValue()).thenReturn("formula result");
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"str\"><f>=A3+B4</f><v>formula result</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldHandleBooleanFormulae() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.BOOLEAN);
+        when(cell.getCellFormula()).thenReturn("=A3+B4");
+        when(cell.getBooleanCellValue()).thenReturn(true);
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"b\"><f>=A3+B4</f><v>1</v></c>");
+    }
+
+    @Test
+    @SneakyThrows
+    void writeCell_shouldHandleErrorFormulae() {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.ERROR);
+        when(cell.getCellFormula()).thenReturn("=A3+B4");
+        when(cell.getErrorCellValue()).thenReturn(DIV0.getCode());
+
+        reportSheetDataWriter.writeCell(0, cell);
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" t=\"e\"><f>=A3+B4</f><v>#DIV/0!</v></c>");
+    }
+
+}

--- a/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.laa.gpfd.model.ReportQuery;
 import uk.gov.laa.gpfd.model.excel.ExcelSheet;
 
+import java.io.IOException;
 import java.io.StringWriter;
 
 import static org.apache.poi.ss.usermodel.FormulaError.DIV0;
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,18 +39,15 @@ class ReportSheetDataWriterTest {
     @Mock
     ExcelSheet sheet;
 
-
     ReportSheetDataWriter reportSheetDataWriter;
 
     StringWriter buffer;
 
-    @SneakyThrows
     @BeforeEach
     void beforeEach() {
         buffer = new StringWriter();
     }
 
-    @SneakyThrows
     private void createDataWriter() {
         createDataWriter(sharedStringSource);
     }
@@ -68,8 +67,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldDoNothingIfCellNull() {
+    void writeCell_shouldDoNothingIfCellNull() throws IOException {
         createDataWriter();
         reportSheetDataWriter.writeCell(1, null);
 
@@ -77,8 +75,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteBlankCell() {
+    void writeCell_shouldWriteBlankCell() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -91,8 +88,21 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteNumericCell() {
+    void writeCell_shouldWriteStyleIfOneSet() throws IOException {
+        createDataWriter();
+        setupCommonMocks();
+
+        when(cell.getCellType()).thenReturn(CellType.BLANK);
+        when(styleManager.getColumnStyle(anyInt(), any())).thenReturn(32);
+        reportSheetDataWriter.writeCell(0, cell);
+
+        assertThat(buffer.toString())
+                .contains("<c r=\"A1\" s=\"32\"></c>");
+        verify(styleManager.getColumnStyle(0, "testSheet"));
+    }
+
+    @Test
+    void writeCell_shouldWriteNumericCell() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -106,8 +116,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteBooleanCell_withTrueAsOne() {
+    void writeCell_shouldWriteBooleanCell_withTrueAsOne() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -121,8 +130,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteBooleanCell_withFalseAsZero() {
+    void writeCell_shouldWriteBooleanCell_withFalseAsZero() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -136,8 +144,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_fromSharedStringSource() {
+    void writeCell_shouldWriteStringCell_fromSharedStringSource() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -152,8 +159,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_whenNoSharedStringSource() {
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource() throws IOException {
         createDataWriter(null);
         setupCommonMocks();
 
@@ -166,8 +172,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveLeadingSpaces() {
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveLeadingSpaces() throws IOException {
         createDataWriter(null);
         setupCommonMocks();
 
@@ -180,8 +185,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveTrailingSpaces() {
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldPreserveTrailingSpaces() throws IOException {
         createDataWriter(null);
         setupCommonMocks();
 
@@ -194,8 +198,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleEmptyString() {
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleEmptyString() throws IOException {
         createDataWriter(null);
         setupCommonMocks();
 
@@ -208,8 +211,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleNullString() {
+    void writeCell_shouldWriteStringCell_whenNoSharedStringSource_shouldHandleNullString() throws IOException {
         createDataWriter(null);
         setupCommonMocks();
 
@@ -222,8 +224,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldWriteErrorCell() {
+    void writeCell_shouldWriteErrorCell() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -236,8 +237,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldHandleNumericFormulae() {
+    void writeCell_shouldHandleNumericFormulae() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -252,8 +252,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldHandleStringFormulae() {
+    void writeCell_shouldHandleStringFormulae() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -268,8 +267,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldHandleBooleanFormulae() {
+    void writeCell_shouldHandleBooleanFormulae() throws IOException {
         createDataWriter();
         setupCommonMocks();
 
@@ -284,8 +282,7 @@ class ReportSheetDataWriterTest {
     }
 
     @Test
-    @SneakyThrows
-    void writeCell_shouldHandleErrorFormulae() {
+    void writeCell_shouldHandleErrorFormulae() throws IOException {
         createDataWriter();
         setupCommonMocks();
 

--- a/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/services/excel/workbook/ReportSheetDataWriterTest.java
@@ -98,7 +98,7 @@ class ReportSheetDataWriterTest {
 
         assertThat(buffer.toString())
                 .contains("<c r=\"A1\" s=\"32\"></c>");
-        verify(styleManager.getColumnStyle(0, "testSheet"));
+        verify(styleManager).getColumnStyle(0, "testSheet");
     }
 
     @Test


### PR DESCRIPTION
JIRA: [LPF-1189 (kinda)](https://dsdmoj.atlassian.net/browse/LPF-1189)

## Description of changes
Noting that the CI pipeline oft ignores the test coverage provided from the `AuthTokenIT`
And Noting that the `ReportSheetDataWriter`, despite being essential to our Excel generation, was only being covered by this IT and no unit-level tests

Add unit tests to ensure that cells are generated correctly

And uncovering a bug via these tests in the way it handles "cached Boolean formula cells", fix said bug

## Evidence
<img width="695" height="507" alt="image" src="https://github.com/user-attachments/assets/c07a70da-7244-40f6-a34f-b6debe60b560" />

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history