### PR TITLE
fix: Oracle health check in docker compose stops app running too early

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     mem_limit: 2g
     shm_size: 1g
     healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/1521"]
+      test: ["CMD", "healthcheck.sh"]
       interval: 15s
       timeout: 10s
       retries: 20
@@ -36,7 +36,7 @@ services:
       oracle:
         condition: service_healthy        # wait for Oracle to be ready
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/1521"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
JIRA: [Nope](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
- Switch Oracle container health check to use the oracle containers default
- 
## Evidence
- the pfla app stops trying to start before oracle is ready, which it currently does and then complains no db or no user setup etc.

## Checklist
- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history