### PR TITLE
fix(LPF-1378): remove commit message enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,3 @@ repos:
     rev: 772d7ffaeee5d611a904cc564a3fe3c7ad927635 #v3.2.0
     hooks:
       - id: conventional-pre-commit
-
-  - repo: local
-    hooks:
-      - id: valid-commit-format
-        name: Validate commit message format (with ticket ID)
-        entry:
-          bash -c 'grep -Eq "^(feat|fix|docs|chore|refactor|test|ci|build|perf)(\([A-Z]+-[0-9]+\))?: .+" <<< "$(cat "$1")"'
-        language: system
-        stages: [ commit-msg ]

--- a/README.md
+++ b/README.md
@@ -375,9 +375,8 @@ https://learn.microsoft.com/en-us/azure/developer/java/spring-framework/spring-b
 # Pre commit hooks
 
 - Pre commit hooks have been set up on this repository to ensure no accidental commits of secrets, keys etc. Provided by DevSecOps https://github.com/ministryofjustice/devsecops-hooks
-- Pre commit hooks have been set up to ensure commit messages follow the correct format for release-please, which automates our releases. See the [Releases](#releases) section for more details.
 
-Install both hooks with the following command:
+Install the hook with the following command:
 ```text
 pre-commit install
 ```


### PR DESCRIPTION
JIRA: [LPF-1378](https://dsdmoj.atlassian.net/browse/LPF-1378)

## Description of changes
- Removed pre-commit hook introduced in [PR 478](https://github.com/ministryofjustice/payforlegalaid/pull/478)
- Updated README to reflect changes.

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [x] Clean commit history

[LPF-1378]: https://dsdmoj.atlassian.net/browse/LPF-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ