### PR TITLE
chore: conventional commit regex in PR validation update

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Checking PR title: $TITLE"
 
           if echo "$TITLE" | grep -Eq \
-            '^(feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\): .+|^chore(.+): .+'; then
+            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$'; then
             echo "✅ PR title format is valid"
           else
             echo "❌ Invalid PR title format"


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
Tweak regex validation done on PR titles to allow
a) breaking changes to be flagged - this means we can use the Release Please major version update increment feature
b) chores to avoid the optional context - we use this context for ticket number usually, but most chores do not have tickets - this stops us having to force in LPF-000 when we want to fix say Snyk issues, while still enforcing the context for other types - we should not be doing features, bug fixes, refactors without tickets.

## Evidence
<img width="1452" height="772" alt="image" src="https://github.com/user-attachments/assets/898beb90-e6a7-4dbe-870c-490f95763623" />
This PR title passes validation.

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history