### PR TITLE
ci(LPF-000): skip snapshots, update deployment process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,9 @@ jobs:
           is_release=false
 
           if [[ "$EVENT_NAME" == "push" ]]; then
-            msg="$COMMIT_MSG"
+            msg="${COMMIT_MSG:-}"
 
-            if [[ "$msg" =~ ^chore(\([^)]+\))?:\ release\ [0-9] ]]; then
+            if [[ -n "$msg" ]] && [[ "$msg" == chore\(main\):\ release* ]]; then
               is_release=true
             fi
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
 
     steps:
       - id: check
+        name: Check if deployment is a release merge
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ on:
           - uat
           - all
 
-# One deployment at a time on main; queue later runs instead of cancelling mid-deploy.
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: false
@@ -33,30 +32,41 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_release_merge: ${{ steps.check.outputs.is_release_merge }}
+
     steps:
       - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           is_release=false
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            msg="${{ github.event.head_commit.message }}"
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            msg="$COMMIT_MSG"
+
             if [[ "$msg" =~ ^chore(\([^)]+\))?:\ release\ [0-9] ]]; then
               is_release=true
             fi
           fi
-          echo "is_release_merge=$is_release" >> $GITHUB_OUTPUT
+
+          echo "is_release_merge=$is_release" >> "$GITHUB_OUTPUT"
 
       - name: Deployment summary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_SCOPE: ${{ inputs.deploy_scope }}
+          IS_RELEASE: ${{ steps.check.outputs.is_release_merge }}
         run: |
           echo "## Deployment Plan" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-  
-          echo "- Event: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-  
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "- Scope: ${{ inputs.deploy_scope }}" >> $GITHUB_STEP_SUMMARY
+
+          echo "- Event: $EVENT_NAME" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "- Scope: $DEPLOY_SCOPE" >> $GITHUB_STEP_SUMMARY
           fi
-  
-          echo "- Release merge: ${{ steps.check.outputs.is_release_merge }}" >> $GITHUB_STEP_SUMMARY
+
+          echo "- Release merge: $IS_RELEASE" >> $GITHUB_STEP_SUMMARY
 
   To_Dev:
     name: Deploy to dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,67 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      deploy_scope:
+        description: >-
+          For feature branches / ad-hoc deploys (merges to main do not auto-deploy except release-please).
+          dev — development only.
+          dev-uat — development then UAT (UAT requires approval).
+          uat — UAT only (does not deploy dev first).
+          all — development, UAT, then prod.
+        type: choice
+        required: true
+        default: dev
+        options:
+          - dev
+          - dev-uat
+          - uat
+          - all
+
+# One deployment at a time on main; queue later runs instead of cancelling mid-deploy.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  release_check:
+    name: Determine deployment path
+    runs-on: ubuntu-latest
+    outputs:
+      is_release_merge: ${{ steps.check.outputs.is_release_merge }}
+    steps:
+      - id: check
+        run: |
+          is_release=false
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            msg="${{ github.event.head_commit.message }}"
+            if [[ "$msg" =~ ^chore(\([^)]+\))?:\ release\ [0-9] ]]; then
+              is_release=true
+            fi
+          fi
+          echo "is_release_merge=$is_release" >> $GITHUB_OUTPUT
+
+      - name: Deployment summary
+        run: |
+          echo "## Deployment Plan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+  
+          echo "- Event: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+  
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "- Scope: ${{ inputs.deploy_scope }}" >> $GITHUB_STEP_SUMMARY
+          fi
+  
+          echo "- Release merge: ${{ steps.check.outputs.is_release_merge }}" >> $GITHUB_STEP_SUMMARY
+
   To_Dev:
     name: Deploy to dev
+    needs: release_check
+    if: >-
+      github.event_name == 'push'
+      || inputs.deploy_scope == 'dev'
+      || inputs.deploy_scope == 'dev-uat'
+      || inputs.deploy_scope == 'all'
     uses: ./.github/workflows/deploy_api_to_env.yml
     with:
       github_environment: development
@@ -28,7 +85,14 @@ jobs:
 
   To_Uat:
     name: Deploy to UAT
-    needs: To_Dev
+    needs: [release_check, To_Dev]
+    if: >-
+      always()
+      && (needs.To_Dev.result == 'success' || needs.To_Dev.result == 'skipped')
+      && ((github.event_name == 'push' && needs.release_check.outputs.is_release_merge == 'true')
+        || inputs.deploy_scope == 'uat'
+        || inputs.deploy_scope == 'dev-uat'
+        || inputs.deploy_scope == 'all')
     uses: ./.github/workflows/deploy_api_to_env.yml
     with:
       github_environment: uat
@@ -48,7 +112,12 @@ jobs:
 
   To_Prod:
     name: Deploy to prod
-    needs: To_Uat
+    needs: [release_check, To_Uat]
+    if: >-
+      always()
+      && needs.To_Uat.result == 'success'
+      && ((github.event_name == 'push' && needs.release_check.outputs.is_release_merge == 'true')
+        || inputs.deploy_scope == 'all')
     uses: ./.github/workflows/deploy_api_to_env.yml
     with:
       github_environment: prod

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 #v5.0.0
         with:
           release-type: maven
+          skip-snapshot: true

--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ The workflow runs the same Maven Gatling command and uploads the generated repor
 
 GitHub Actions is used for CI/CD.
 
+### Deployments (`One to deploy them all`)
+
+| Trigger | Behaviour |
+|---------|-----------|
+| Push to `main` (feature/fix commits) | **Dev only** — automatically deploys latest merge to dev |
+| Push to `main` (release commit, e.g. `chore(main): release x.x.x`) | **Dev → UAT → prod** — automatic promotion of the versioned release (UAT and prod require environment approval) |
+| Manual run (any branch), scope **dev** | Dev only |
+| Manual run, scope **dev-uat** | Dev, then UAT (UAT approval required) |
+| Manual run, scope **uat** | UAT only for the selected branch/commit (skips dev) |
+| Manual run, scope **all** | Dev → UAT → prod |
+
+To test a feature before release: run the workflow from your branch via **Actions → One to deploy them all → Run workflow**, choose the branch and scope.
+
+Deployments on the same branch are queued rather than cancelling an in-progress deployment.
+
 # Releases
 
 This project uses [release-please](https://github.com/googleapis/release-please)
@@ -272,6 +287,7 @@ When the Release PR is merged:
 - a Git tag is created
 - a GitHub Release is published
 - the new version becomes available
+- the deploy workflow promotes that commit through dev, UAT, and prod (so deployed artefacts align with the released version)
 
 ---
 


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
- Updated release-please to stop creating snapshot PR's
- Updated deploy.yml
1. release-please PR merges trigger automatic deployments from dev -> prod (no change to existing 'review required')
2. feature branch merges now only trigger automatic deployments to dev ONLY, not beyond
3. created workflow dispatch, so that for testing purposes we can manually deploy changes to: dev, uat, dev+uat, or for hotfixes etc can deploy from dev -> prod. Removes the need to have to keep cancelling workflows before hitting uat/prod to test dev/uat

<img width="1536" height="1024" alt="workflow_diagram" src="https://github.com/user-attachments/assets/883f9965-e280-4b3a-8ec1-08d74b3c61b0" />


## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history