### PR TITLE
chore: Update Netty Codec to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,11 @@
             <artifactId>netty-resolver-dns</artifactId>
             <version>4.2.15.Final</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-classes-quic</artifactId>
+            <version>4.2.15.Final</version>
+        </dependency>
         <!-- Override transitive dependency - Spring Boot on 7.0.7 needs at least 7.0.8 -->
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
- Update Netty Codec Classes Quic to avoid CVE
- It is used by one of the other Nettys. 
- This is a short term measure to unblock pipelines and later this week we should have new Spring Boot and remove it.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history