### PR TITLE
feat(LPF-1453): add metrics for mojfin connection

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/AppConfig.java
@@ -102,7 +102,7 @@ public class AppConfig {
      * @return a configured {@link DataSource} for read-only operations.
      */
     @Bean
-    public DataSource readOnlyDataSource(
+    public PoolDataSource readOnlyDataSource(
             @Value("${gpfd.datasource.read-only.url}") String url,
             @Value("${gpfd.datasource.read-only.username}") String username,
             @Value("${gpfd.datasource.read-only.password}") String password,

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/MetricsConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/MetricsConfig.java
@@ -1,0 +1,32 @@
+package uk.gov.laa.gpfd.config.metrics;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class MetricsConfig {
+    /**
+     * Create a metric registry to collect Oracle/MOJFIN connection pool metrics and send to Prometheus
+     * We pass in the generic DataSource and then check the type just to avoid typing and injection issues when running the integration tests.
+     * @param readOnlyDataSource - the MOJFIN data source
+     * @return metric registry
+     */
+    @Bean
+    @ConditionalOnBean(name="readOnlyDataSource")
+    public MeterBinder readUcpMetricsBinder(@Qualifier("readOnlyDataSource") DataSource readOnlyDataSource) {
+
+        return meterRegistry -> {
+            if (readOnlyDataSource instanceof PoolDataSource readOnlyPool) {
+                new UcpMetricsBinder(readOnlyPool, Tag.of("datasource", "readOnly")).bindTo(meterRegistry);
+            }
+        };
+    }
+
+}

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinder.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinder.java
@@ -1,0 +1,118 @@
+package uk.gov.laa.gpfd.config.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.jspecify.annotations.NonNull;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class UcpMetricsBinder implements MeterBinder {
+
+    private final PoolDataSource dataSource;
+    private final Tag sourceTag;
+
+    public UcpMetricsBinder(PoolDataSource dataSource, Tag sourceTag) {
+        this.dataSource = dataSource;
+        this.sourceTag = sourceTag;
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry meterRegistry) {
+
+        var tags = List.of(sourceTag);
+
+        Gauge.builder("ucp.connections.total", dataSource,
+                        poolDataSource -> {
+                            var stats = poolDataSource.getStatistics();
+                            if (stats == null) {
+                                return Double.NaN;
+                            }
+                            return stats.getTotalConnectionsCount();
+                        })
+                .tags(tags)
+                .description("Total pool connections")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.available", dataSource, poolDataSource -> {
+                    try {
+                        return poolDataSource.getAvailableConnectionsCount();
+                    } catch (SQLException e) {
+                        return Double.NaN;
+                    }
+                })
+                .tags(tags)
+                .description("Available (idle) connections")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.borrowed", dataSource, poolDataSource -> {
+                    try {
+                        return poolDataSource.getBorrowedConnectionsCount();
+                    } catch (SQLException e) {
+                        return Double.NaN;
+                    }
+                })
+                .tags(tags)
+                .description("Borrowed (active) connections")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.maximum", dataSource, PoolDataSource::getMaxPoolSize)
+                .tags(tags)
+                .description("Maximum connections")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.pending", dataSource,
+                        poolDataSource -> {
+                            var stats = poolDataSource.getStatistics();
+                            if (stats == null) {
+                                return Double.NaN;
+                            }
+                            return stats.getPendingRequestsCount();
+                        })
+                .tags(tags)
+                .description("Connections pending")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.created", dataSource,
+                        poolDataSource -> {
+                            var stats = poolDataSource.getStatistics();
+                            if (stats == null) {
+                                return Double.NaN;
+                            }
+                            return stats.getConnectionsCreatedCount();
+                        })
+                .tags(tags)
+                .description("Connections created")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.closed", dataSource,
+                        poolDataSource -> {
+                            var stats = poolDataSource.getStatistics();
+                            if (stats == null) {
+                                return Double.NaN;
+                            }
+                            return stats.getConnectionsClosedCount();
+                        })
+                .tags(tags)
+                .description("Connections closed")
+                .register(meterRegistry);
+
+        Gauge.builder("ucp.connections.utilisation", dataSource,
+                        poolDataSource -> {
+                            try {
+                                var active = poolDataSource.getBorrowedConnectionsCount();
+                                var max = poolDataSource.getMaxPoolSize();
+                                return max == 0 ? Double.NaN : (double) active / max;
+                            } catch (SQLException e) {
+                                return Double.NaN;
+                            }
+                        })
+                .tags(tags)
+                .description("Ratio of active pools to max pool usage")
+                .register(meterRegistry);
+
+    }
+}

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinder.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinder.java
@@ -40,7 +40,7 @@ public class UcpMetricsBinder implements MeterBinder {
         Gauge.builder("ucp.connections.available", dataSource, poolDataSource -> {
                     try {
                         return poolDataSource.getAvailableConnectionsCount();
-                    } catch (SQLException e) {
+                    } catch (SQLException _) {
                         return Double.NaN;
                     }
                 })
@@ -51,7 +51,7 @@ public class UcpMetricsBinder implements MeterBinder {
         Gauge.builder("ucp.connections.borrowed", dataSource, poolDataSource -> {
                     try {
                         return poolDataSource.getBorrowedConnectionsCount();
-                    } catch (SQLException e) {
+                    } catch (SQLException _) {
                         return Double.NaN;
                     }
                 })
@@ -106,7 +106,7 @@ public class UcpMetricsBinder implements MeterBinder {
                                 var active = poolDataSource.getBorrowedConnectionsCount();
                                 var max = poolDataSource.getMaxPoolSize();
                                 return max == 0 ? Double.NaN : (double) active / max;
-                            } catch (SQLException e) {
+                            } catch (SQLException _) {
                                 return Double.NaN;
                             }
                         })

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ management:
     health:
       probes:
         enabled: true
+  metrics:
+    tags:
+      instance: ${HOSTNAME:local}
 
 springdoc:
   api-docs:

--- a/src/test/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinderTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/metrics/UcpMetricsBinderTest.java
@@ -1,0 +1,257 @@
+package uk.gov.laa.gpfd.config.metrics;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import oracle.ucp.jdbc.JDBCConnectionPoolStatistics;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UcpMetricsBinderTest {
+
+    private static final Tag MOCK_SOURCE_TAG = Tag.of("datasource", "mocking");
+
+    @Test
+    void shouldExposeBorrowedConnections() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getBorrowedConnectionsCount()).thenReturn(3);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.borrowed").gauge();
+        assertNotNull(gauge);
+        assertEquals(3, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfBorrowedConnectionCallErrors() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getBorrowedConnectionsCount()).thenThrow(new SQLException("Error :("));
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.borrowed").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldExposeAvailableConnections() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getAvailableConnectionsCount()).thenReturn(7);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.available").gauge();
+        assertNotNull(gauge);
+        assertEquals(7, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfAvailableConnectionCallErrors() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getAvailableConnectionsCount()).thenThrow(new SQLException("Error :("));
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.available").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldExposeTotalConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+        var statistics = mock(JDBCConnectionPoolStatistics.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(statistics);
+        when(statistics.getTotalConnectionsCount()).thenReturn(11);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.total").gauge();
+        assertNotNull(gauge);
+        assertEquals(11, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfStatisticsNotDefinedYetForTotalConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(null);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.total").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldExposeMaximumConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getMaxPoolSize()).thenReturn(101);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.maximum").gauge();
+        assertNotNull(gauge);
+        assertEquals(101, gauge.value());
+    }
+
+    @Test
+    void shouldExposePendingConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+        var statistics = mock(JDBCConnectionPoolStatistics.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(statistics);
+        when(statistics.getPendingRequestsCount()).thenReturn(3);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.pending").gauge();
+        assertNotNull(gauge);
+        assertEquals(3, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfStatisticsNotDefinedYetForPendingConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(null);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.pending").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldExposeCreatedConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+        var statistics = mock(JDBCConnectionPoolStatistics.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(statistics);
+        when(statistics.getConnectionsCreatedCount()).thenReturn(9);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.created").gauge();
+        assertNotNull(gauge);
+        assertEquals(9, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfStatisticsNotDefinedYetForCreatedConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(null);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.created").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldExposeClosedConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+        var statistics = mock(JDBCConnectionPoolStatistics.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(statistics);
+        when(statistics.getConnectionsClosedCount()).thenReturn(31);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.closed").gauge();
+        assertNotNull(gauge);
+        assertEquals(31, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNIfStatisticsNotDefinedYetForClosedConnections() {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getStatistics()).thenReturn(null);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.closed").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+
+    @Test
+    void shouldExposeUtilisation() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getBorrowedConnectionsCount()).thenReturn(3);
+        when(poolDataSource.getMaxPoolSize()).thenReturn(6);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.utilisation").gauge();
+        assertNotNull(gauge);
+        assertEquals(0.5, gauge.value());
+    }
+
+    @Test
+    void shouldReturnNaNForUtilisationIfBorrowedCountErrors() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getBorrowedConnectionsCount()).thenThrow(new SQLException("Error :("));
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.utilisation").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+    @Test
+    void shouldReturnNaNForUtilisationIfMaxIsZero() throws SQLException {
+        var registry = new SimpleMeterRegistry();
+        var poolDataSource = mock(PoolDataSource.class);
+
+        when(poolDataSource.getBorrowedConnectionsCount()).thenReturn(3);
+        when(poolDataSource.getMaxPoolSize()).thenReturn(0);
+
+        new UcpMetricsBinder(poolDataSource, MOCK_SOURCE_TAG).bindTo(registry);
+
+        var gauge = registry.find("ucp.connections.utilisation").gauge();
+        assertNotNull(gauge);
+        assertTrue(Double.isNaN(gauge.value()));
+    }
+
+}


### PR DESCRIPTION
JIRA: [LPF-1453](https://dsdmoj.atlassian.net/browse/LPF-1453)

## Description of changes
- Add metrics for the UCP Connection Pool we use to read data from MOJFIN.
- Added total connections, available connections, borrowed connections, pending connections, maximum connections, created connections ,closed connections, and the utilisation ratio.

## Evidence
<img width="741" height="158" alt="image" src="https://github.com/user-attachments/assets/a08f541a-1d6d-4ce5-8569-5112ca59b81c" />

Some of course make more sense over time, e.g.
<img width="1482" height="315" alt="image" src="https://github.com/user-attachments/assets/92119697-1284-4f3a-aefc-d87bd7f6f550" />

Note a couple (total, created) are missing in the screenshot. This is because they are not usually available straight away - they are lazy initialised. Could remove them but leaving in for now to see if we start getting useful values from them eventually.

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history

[LPF-1453]: https://dsdmoj.atlassian.net/browse/LPF-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ