### PR TITLE
chore: Remove transitive dependencies now Spring Boot has updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,22 +334,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.thymeleaf</groupId>
-                <artifactId>thymeleaf</artifactId>
-                <version>3.1.5.RELEASE</version>
-            </dependency>
-            <dependency>
-                <groupId>org.thymeleaf</groupId>
-                <artifactId>thymeleaf-spring6</artifactId>
-                <version>3.1.5.RELEASE</version>
-            </dependency>
-            <!-- Overriding webmvc version until it is fixed in 4.0.x -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.22</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -483,20 +467,6 @@
             <artifactId>sts</artifactId>
         </dependency>
 
-        <!--- Transitive dependency CVEs - remove if Spring etc upgrade -->
-        <dependency>
-            <!-- Spring currently sitting at 3.0.4 -->
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <!-- SpringDoc Openapi currently sitting at 2.20.2 -->
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.22.0</version>
-        </dependency>
-
         <!-- Test Dependencies-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -604,86 +574,6 @@
             <artifactId>playwright</artifactId>
             <version>${axe.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <!--   Pulling in below Netty dependencies to
-        resolve vulnerabilities raised by Snyk   -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-compression</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-dns</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-epoll</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http3</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-classes-quic</artifactId>
-            <version>4.2.15.Final</version>
-        </dependency>
-        <!-- Override transitive dependency - Spring Boot on 7.0.7 needs at least 7.0.8 -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>7.0.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-            <version>7.0.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-expression</artifactId>
-            <version>7.0.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>7.0.8</version>
-        </dependency>
-        <!-- Override transitive dependency - Spring Boot on 1.16.5 but needs at least 1.16.6 -->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <version>1.17.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.ati
## Description of changes
- Remove transitive dependencies we overrode to keep snyk happy before the upgrade to Spring Boot 4.1
- Update OpenAPI to version that uses Spring Boot 4.1

## Evidence
Pipeline passes

## Checklist
- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history