### PR TITLE
chore: Update action versions dependabot misses

### DIFF
--- a/.github/build-and-test/action.yml
+++ b/.github/build-and-test/action.yml
@@ -6,10 +6,10 @@ runs:
   steps:
 
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Java
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         distribution: 'corretto'
         java-version: '25'

--- a/.github/build-push-docker-image/action.yml
+++ b/.github/build-push-docker-image/action.yml
@@ -5,12 +5,12 @@ runs:
 
   steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Checkout GitHub repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        repository: ministryofjustice/payforlegalaid-swagger
+        repository: ministryofjustice/payforlegalaid-openapi
         path: spec
         ssh-key: ${{ env.SOCKET_KEY }}
 

--- a/.github/checkout-build-openapi/action.yml
+++ b/.github/checkout-build-openapi/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
 
     - name: Setup Java
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         distribution: 'corretto'
         java-version: '25'
@@ -34,7 +34,7 @@ runs:
         bash
 
     - name: Checkout openapi spec
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       env:
         OPENAPI_VERSION: ${{ steps.get_openapi_version.outputs.version }}
       with:

--- a/.github/login-to-aws/action.yml
+++ b/.github/login-to-aws/action.yml
@@ -5,10 +5,10 @@ runs:
 
   steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Assume role in Cloud Platform
-      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         role-to-assume: ${{ env.ROLE }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/run_acceptance_tests/action.yml
+++ b/.github/run_acceptance_tests/action.yml
@@ -11,10 +11,10 @@ runs:
         AWS_REGION: ${{ env.AWS_REGION }}
 
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Java
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         distribution: 'corretto'
         java-version: '25'


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
Dependabot doesn't update action versions inside the action sub-folders currently. Bring them up to date


## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history