### PR TITLE
feat(LPF-1453): Collect tracking DB metrics

### DIFF
--- a/src/main/java/uk/gov/laa/gpfd/Application.java
+++ b/src/main/java/uk/gov/laa/gpfd/Application.java
@@ -3,12 +3,14 @@ package uk.gov.laa.gpfd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class Application {
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
 

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/MetricsConfig.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/MetricsConfig.java
@@ -19,7 +19,7 @@ public class MetricsConfig {
      * @return metric registry
      */
     @Bean
-    @ConditionalOnBean(name="readOnlyDataSource")
+    @ConditionalOnBean(name = "readOnlyDataSource")
     public MeterBinder readUcpMetricsBinder(@Qualifier("readOnlyDataSource") DataSource readOnlyDataSource) {
 
         return meterRegistry -> {

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
@@ -1,0 +1,120 @@
+package uk.gov.laa.gpfd.config.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Bean that holds details on postgres db tracking. It both defines these metrics and handles collecting them
+ * We poll the database for database metrics less often than Prometheus asks for metrics, and store them.
+ * This is to avoid the risk of the database getting spammed by Prometheus requests
+ */
+@Slf4j
+@Component
+@ConditionalOnBean(name = "trackingJdbcTemplate")
+public class PostgresMetricsCollector implements MeterBinder {
+
+    private final JdbcTemplate trackingJdbcTemplate;
+
+    private final AtomicInteger totalConnections = new AtomicInteger();
+    private final AtomicInteger activeConnections = new AtomicInteger();
+    private final AtomicInteger idleConnections = new AtomicInteger();
+    private final AtomicInteger maxConnections = new AtomicInteger();
+    private final AtomicInteger committedTransactions = new AtomicInteger();
+    private final AtomicInteger rolledBackTransaction = new AtomicInteger();
+
+    private final List<Tag> trackingTag = List.of(Tag.of("datasource", "tracking"));
+    
+    public PostgresMetricsCollector(@Qualifier("trackingJdbcTemplate") JdbcTemplate trackingJdbcTemplate) {
+        this.trackingJdbcTemplate = trackingJdbcTemplate;
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry meterRegistry) {
+
+        Gauge.builder("db.tracking.connections.total", totalConnections, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Total open connections to the database")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.connections.active", activeConnections, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Total active connections to the database")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.connections.idle", idleConnections, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Total idle connections to the database")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.connections.max", maxConnections, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Max connections")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.transactions.commits", committedTransactions, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Total number of committed transactions (database activity, including reads and writes)")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.transactions.rollbacks", rolledBackTransaction, AtomicInteger::get)
+                .tags(trackingTag)
+                .description("Total number of failed transactions (rollbacks)")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.connections.utilisation.active",
+                        () -> maxConnections.get() == 0 ? Double.NaN : activeConnections.get() / (double) maxConnections.get())
+                .tags(trackingTag)
+                .description("Active utilisation rate (active/max)")
+                .register(meterRegistry);
+
+        Gauge.builder("db.tracking.connections.utilisation.total_utilisation",
+                        () -> maxConnections.get() == 0 ? Double.NaN : totalConnections.get() / (double) maxConnections.get())
+                .tags(trackingTag)
+                .description("Total utilisation rate (total/max)")
+                .register(meterRegistry);
+
+    }
+
+    // Only run every 30s to avoid hammering the db
+    @Scheduled(fixedDelay = 30000)
+    public void pollTrackingDbMetrics() {
+        log.info("Querying Report Tracking db for metrics");
+        try {
+            var total = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity", Integer.class);
+            totalConnections.set(total == null ? 0 : total);
+
+            var active = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity WHERE state = 'active'", Integer.class);
+            activeConnections.set(active == null ? 0 : active);
+
+            var idle = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity WHERE state = 'idle'", Integer.class);
+            idleConnections.set(idle == null ? 0 : idle);
+
+            var max = trackingJdbcTemplate.queryForObject("SHOW max_connections", Integer.class);
+            maxConnections.set(max == null ? 0 : max);
+
+            var committed = trackingJdbcTemplate.queryForObject("SELECT xact_commit FROM pg_stat_database WHERE datname = current_database()", Integer.class);
+            committedTransactions.set(committed == null ? 0 : committed);
+
+            var rollbacks = trackingJdbcTemplate.queryForObject("SELECT xact_rollback FROM pg_stat_database WHERE datname = current_database()", Integer.class);
+            rolledBackTransaction.set(rollbacks == null ? 0 : rollbacks);
+
+
+        } catch (DataAccessException e) {
+            log.warn("Failed to poll Postgres metrics", e);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
@@ -26,6 +26,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 @ConditionalOnBean(name = "trackingJdbcTemplate")
 public class PostgresMetricsCollector implements MeterBinder {
 
+    protected static final String SQL_TOTAL_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity";
+    protected static final String SQL_ACTIVE_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity WHERE state = 'active'";
+    protected static final String SQL_IDLE_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity WHERE state = 'idle'";
+    protected static final String SQL_MAX_CONNECTIONS = "SHOW max_connections";
+    protected static final String SQL_COMMITTED_TRANSACTIONS = "SELECT xact_commit FROM pg_stat_database WHERE datname = current_database()";
+    protected static final String SQL_ROLLBACK_TRANSACTIONS = "SELECT xact_rollback FROM pg_stat_database WHERE datname = current_database()";
+
     private final JdbcTemplate trackingJdbcTemplate;
 
     private final AtomicInteger totalConnections = new AtomicInteger();
@@ -36,7 +43,7 @@ public class PostgresMetricsCollector implements MeterBinder {
     private final AtomicInteger rolledBackTransaction = new AtomicInteger();
 
     private final List<Tag> trackingTag = List.of(Tag.of("datasource", "tracking"));
-    
+
     public PostgresMetricsCollector(@Qualifier("trackingJdbcTemplate") JdbcTemplate trackingJdbcTemplate) {
         this.trackingJdbcTemplate = trackingJdbcTemplate;
     }
@@ -80,6 +87,7 @@ public class PostgresMetricsCollector implements MeterBinder {
                 .description("Active utilisation rate (active/max)")
                 .register(meterRegistry);
 
+        // Metric name can't end in total!
         Gauge.builder("db.tracking.connections.utilisation.total_utilisation",
                         () -> maxConnections.get() == 0 ? Double.NaN : totalConnections.get() / (double) maxConnections.get())
                 .tags(trackingTag)
@@ -93,24 +101,23 @@ public class PostgresMetricsCollector implements MeterBinder {
     public void pollTrackingDbMetrics() {
         log.info("Querying Report Tracking db for metrics");
         try {
-            var total = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity", Integer.class);
+            var total = trackingJdbcTemplate.queryForObject(SQL_TOTAL_CONNECTIONS, Integer.class);
             totalConnections.set(total == null ? 0 : total);
 
-            var active = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity WHERE state = 'active'", Integer.class);
+            var active = trackingJdbcTemplate.queryForObject(SQL_ACTIVE_CONNECTIONS, Integer.class);
             activeConnections.set(active == null ? 0 : active);
 
-            var idle = trackingJdbcTemplate.queryForObject("SELECT count(*) FROM pg_stat_activity WHERE state = 'idle'", Integer.class);
+            var idle = trackingJdbcTemplate.queryForObject(SQL_IDLE_CONNECTIONS, Integer.class);
             idleConnections.set(idle == null ? 0 : idle);
 
-            var max = trackingJdbcTemplate.queryForObject("SHOW max_connections", Integer.class);
+            var max = trackingJdbcTemplate.queryForObject(SQL_MAX_CONNECTIONS, Integer.class);
             maxConnections.set(max == null ? 0 : max);
 
-            var committed = trackingJdbcTemplate.queryForObject("SELECT xact_commit FROM pg_stat_database WHERE datname = current_database()", Integer.class);
+            var committed = trackingJdbcTemplate.queryForObject(SQL_COMMITTED_TRANSACTIONS, Integer.class);
             committedTransactions.set(committed == null ? 0 : committed);
 
-            var rollbacks = trackingJdbcTemplate.queryForObject("SELECT xact_rollback FROM pg_stat_database WHERE datname = current_database()", Integer.class);
+            var rollbacks = trackingJdbcTemplate.queryForObject(SQL_ROLLBACK_TRANSACTIONS, Integer.class);
             rolledBackTransaction.set(rollbacks == null ? 0 : rollbacks);
-
 
         } catch (DataAccessException e) {
             log.warn("Failed to poll Postgres metrics", e);

--- a/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
+++ b/src/main/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollector.java
@@ -99,7 +99,7 @@ public class PostgresMetricsCollector implements MeterBinder {
     // Only run every 30s to avoid hammering the db
     @Scheduled(fixedDelay = 30000)
     public void pollTrackingDbMetrics() {
-        log.info("Querying Report Tracking db for metrics");
+        log.debug("Querying Report Tracking db for metrics");
         try {
             var total = trackingJdbcTemplate.queryForObject(SQL_TOTAL_CONNECTIONS, Integer.class);
             totalConnections.set(total == null ? 0 : total);

--- a/src/test/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollectorTest.java
+++ b/src/test/java/uk/gov/laa/gpfd/config/metrics/PostgresMetricsCollectorTest.java
@@ -1,0 +1,261 @@
+package uk.gov.laa.gpfd.config.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_ACTIVE_CONNECTIONS;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_COMMITTED_TRANSACTIONS;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_IDLE_CONNECTIONS;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_MAX_CONNECTIONS;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_ROLLBACK_TRANSACTIONS;
+import static uk.gov.laa.gpfd.config.metrics.PostgresMetricsCollector.SQL_TOTAL_CONNECTIONS;
+
+@ExtendWith(MockitoExtension.class)
+class PostgresMetricsCollectorTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void before() {
+        reset(jdbcTemplate);
+        when(jdbcTemplate.queryForObject(SQL_TOTAL_CONNECTIONS, Integer.class)).thenReturn(23);
+        when(jdbcTemplate.queryForObject(SQL_ACTIVE_CONNECTIONS, Integer.class)).thenReturn(5);
+        when(jdbcTemplate.queryForObject(SQL_IDLE_CONNECTIONS, Integer.class)).thenReturn(13);
+        when(jdbcTemplate.queryForObject(SQL_MAX_CONNECTIONS, Integer.class)).thenReturn(1234);
+        when(jdbcTemplate.queryForObject(SQL_COMMITTED_TRANSACTIONS, Integer.class)).thenReturn(986421);
+        when(jdbcTemplate.queryForObject(SQL_ROLLBACK_TRANSACTIONS, Integer.class)).thenReturn(79);
+
+    }
+
+    @Test
+    void shouldExposeTotalConnections() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.total").gauge();
+        assertNotNull(gauge);
+        assertEquals(23, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingTotalConnections() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_TOTAL_CONNECTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.total").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldExposeActiveConnections() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.active").gauge();
+        assertNotNull(gauge);
+        assertEquals(5, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingActiveConnections() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_ACTIVE_CONNECTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.active").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldExposeIdleConnections() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.idle").gauge();
+        assertNotNull(gauge);
+        assertEquals(13, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingIdleConnections() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_IDLE_CONNECTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.idle").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldExposeMaxConnections() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.max").gauge();
+        assertNotNull(gauge);
+        assertEquals(1234, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingMaxConnections() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_MAX_CONNECTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.max").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldExposeCommittedTransactions() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.transactions.commits").gauge();
+        assertNotNull(gauge);
+        assertEquals(986421, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingCommittedConnections() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_COMMITTED_TRANSACTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.transactions.commits").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldExposeRollbackTransactions() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.transactions.rollbacks").gauge();
+        assertNotNull(gauge);
+        assertEquals(79, gauge.value());
+    }
+
+    @Test
+    void shouldZeroIfErrorFetchingRollbackTransactions() {
+        var registry = new SimpleMeterRegistry();
+        when(jdbcTemplate.queryForObject(SQL_ROLLBACK_TRANSACTIONS, Integer.class)).thenReturn(null);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.transactions.rollbacks").gauge();
+        assertNotNull(gauge);
+        assertEquals(0, gauge.value());
+    }
+
+    @Test
+    void shouldCalculateActiveUtilisationRate() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.utilisation.active").gauge();
+        assertNotNull(gauge);
+        assertEquals((double) 5 / 1234, gauge.value());
+    }
+
+    @Test
+    void shouldCalculateTotalUtilisationRate() {
+        var registry = new SimpleMeterRegistry();
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gauge = registry.find("db.tracking.connections.utilisation.total_utilisation").gauge();
+        assertNotNull(gauge);
+        assertEquals((double) 23 / 1234, gauge.value());
+    }
+
+    @Test
+    void shouldNaNWhenCalculatingIfMaxIsZero() {
+        var registry = new SimpleMeterRegistry();
+
+        when(jdbcTemplate.queryForObject(SQL_MAX_CONNECTIONS, Integer.class)).thenReturn(0);
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+        var gaugeActive = registry.find("db.tracking.connections.utilisation.active").gauge();
+        assertNotNull(gaugeActive);
+        assertEquals(Double.NaN, gaugeActive.value());
+
+        var gaugeTotal = registry.find("db.tracking.connections.utilisation.total_utilisation").gauge();
+        assertNotNull(gaugeTotal);
+        assertEquals(Double.NaN, gaugeTotal.value());
+
+    }
+
+    @Test
+    void shouldCatchSqlExceptionsAndAllowProgramToContinue() {
+        var registry = new SimpleMeterRegistry();
+
+        when(jdbcTemplate.queryForObject(SQL_ROLLBACK_TRANSACTIONS, Integer.class)).thenThrow(new QueryTimeoutException("Uh oh"));
+
+        var metrics = new PostgresMetricsCollector(jdbcTemplate);
+        metrics.pollTrackingDbMetrics();
+        metrics.bindTo(registry);
+
+    }
+
+}


### PR DESCRIPTION
JIRA: [LPF-1453](https://dsdmoj.atlassian.net/browse/LPF-1453)

Merging into SILAS FB

## Description of changes
- Add metrics for Postgres tracking db
- They are collected from the db at regular intervals (currently 30s) and stored so that they are available for whenever Prometheus pings for metrics.

## Evidence
<img width="1700" height="433" alt="image" src="https://github.com/user-attachments/assets/9c39e269-66c1-410e-a38d-9c1635eee418" />

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history

[LPF-1453]: https://dsdmoj.atlassian.net/browse/LPF-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ