### PR TITLE
build(LPF-1514): adopt glad parent bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,22 +17,14 @@
         <oracle-jdbc.version>23.26.2.0.0</oracle-jdbc.version>
         <h2.version>2.4.240</h2.version>
         <spring-security.version>7.0.5</spring-security.version>
-        <springdoc-oas.version>3.0.3</springdoc-oas.version>
 
         <!-- Downgraded due to a known issue: https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter  (until the 2.0.x release becomes available) -->
         <maven-surefire-junit5-tree-reporter.version>1.5.1</maven-surefire-junit5-tree-reporter.version>
-        <poi.version>5.5.1</poi.version>
         <immutables.version>2.12.2</immutables.version>
-        <spring-cloud-azure-dependencies.version>7.3.0</spring-cloud-azure-dependencies.version>
         <govuk-frontend.version>6.3.0</govuk-frontend.version>
         <moj-frontend.version>6.0.0</moj-frontend.version>
 
-        <payforlegalaid-openapi.version>0.0.40</payforlegalaid-openapi.version>
         <glad-bom.version>0.1.0</glad-bom.version>
-        <aws.java.sdk.version>2.46.18</aws.java.sdk.version>
-        <cucumber.version>7.34.4</cucumber.version>
-        <playwright.version>1.61.0</playwright.version>
-        <axe.version>4.12.0</axe.version>
 
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
@@ -47,10 +39,6 @@
         <!-- Code coverage thresholds: fail build if coverage falls below these values -->
         <coverage.line.minimum>0.80</coverage.line.minimum>
         <coverage.branch.minimum>0.68</coverage.branch.minimum>
-
-        <!-- Snyk vulns -->
-        <logback.version>1.5.37</logback.version>
-        <tomcat.version>11.0.23</tomcat.version>
     </properties>
 
     <build>
@@ -131,7 +119,6 @@
                                 <artifactItem>
                                     <groupId>uk.gov.laa</groupId>
                                     <artifactId>payforlegalaid-openapi</artifactId>
-                                    <version>${payforlegalaid-openapi.version}</version>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.basedir}/src/main/resources/static</outputDirectory>
@@ -319,27 +306,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.cucumber</groupId>
-                <artifactId>cucumber-bom</artifactId>
-                <version>${cucumber.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.azure.spring</groupId>
-                <artifactId>spring-cloud-azure-dependencies</artifactId>
-                <version>${spring-cloud-azure-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>${aws.java.sdk.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>uk.gov.laa</groupId>
                 <artifactId>glad-bom</artifactId>
                 <version>${glad-bom.version}</version>
@@ -359,28 +325,23 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>${poi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>${poi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml-full</artifactId>
-            <version>${poi.version}</version>
         </dependency>
 
         <dependency>
             <groupId>uk.gov.laa</groupId>
             <artifactId>payforlegalaid-openapi</artifactId>
-            <version>${payforlegalaid-openapi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>${springdoc-oas.version}</version>
         </dependency>
 
         <dependency>
@@ -420,12 +381,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat.version}</version>
         </dependency>
 
         <!--  Do not replace with spring-liquibase due to how we configure Liquibase.  -->
@@ -598,13 +557,11 @@
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
-            <version>${playwright.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.deque.html.axe-core</groupId>
             <artifactId>playwright</artifactId>
-            <version>${axe.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <moj-frontend.version>6.0.0</moj-frontend.version>
 
         <payforlegalaid-openapi.version>0.0.40</payforlegalaid-openapi.version>
+        <glad-bom.version>0.1.0</glad-bom.version>
         <aws.java.sdk.version>2.46.18</aws.java.sdk.version>
         <cucumber.version>7.34.4</cucumber.version>
         <playwright.version>1.61.0</playwright.version>
@@ -338,6 +339,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>uk.gov.laa</groupId>
+                <artifactId>glad-bom</artifactId>
+                <version>${glad-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -605,6 +613,10 @@
         <repository>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/ministryofjustice/glad-parent-bom</url>
         </repository>
         <repository>
             <id>payforlegalaid-openapi</id>


### PR DESCRIPTION
JIRA: [LPF-1514](https://dsdmoj.atlassian.net/browse/LPF-1514)

## Description of changes
We have implemented a new GLAD parent BOM (bill of materials) which manages versions of commonly used dependencies in a central location which are then inherited by projects. This way we only have to change the version number of a dependency in one place and update projects to use the new version of the glad-bom. 

- Cleaned up the pom file in payforlegalaid to remove versions of centrally managed dependencies. 

## Checklist
- [X] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [X] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1514]: https://dsdmoj.atlassian.net/browse/LPF-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ