### PR TITLE
fix(LPF-1538): Add explicit user and group to PFLA container 

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -224,6 +224,8 @@ spec:
                   name: rds-postgresql-instance-output
                   key: database_password
           securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
JIRA: [LPF-1538](https://dsdmoj.atlassian.net/browse/LPF-1538)

## Description of changes
We want to harden container defaults by setting explicit permissions, user roles etc. for security purposes. This PR adds a user and `runAsGroup` value to the PFLA container. 

- Added explicit user and group to PFLA container, similar to liquibase

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
- [X] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [X] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [X] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history

[LPF-1538]: https://dsdmoj.atlassian.net/browse/LPF-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ