### PR TITLE
ci(LPF-1549): raise dependabot as fixes 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(bot)"
+      prefix: "fix(bot)"
     cooldown:
       default-days: 3
     groups:
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(bot)"
+      prefix: "fix(bot)"
     cooldown:
       default-days: 3
     groups:

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Checking PR title: $TITLE"
 
           if echo "$TITLE" | grep -Eq \
-            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$'; then
+            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$|^fix\(bot\): .+$'; then
             echo "✅ PR title format is valid"
           else
             echo "❌ Invalid PR title format"


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-1549)

## Description of changes
- As discussed in tech time, trial getting dependabot to release fixes instead of chores. This way they will trigger the release please and allow us to release these fixes in a more timely and regular fashion.
- Have left github actions updates as chores since they are not deployed code.
- Have updated the PR validation to allow these new titles to work

## Evidence
N/A

## Checklist
- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [x] New tests are included if this a new feature
- [x] Tests and linter checks are passing locally
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history