### PR TITLE
ci(LPF-1549): stop dependabot erroring on access to glad-parent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
           - "patch"
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "uk.gov.laa:glad-parent"
+      - dependency-name: "uk.gov.laa:glad-bom"
+      - dependency-name: "uk.gov.laa:payforlegalaid-openapi"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(bot)"
+      prefix: "fix(bot)"
     cooldown:
       default-days: 3
     groups:
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(bot)"
+      prefix: "fix(bot)"
     cooldown:
       default-days: 3
     groups:

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Checking PR title: $TITLE"
 
           if echo "$TITLE" | grep -Eq \
-            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$'; then
+            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$|^fix\(bot\): .+$'; then
             echo "✅ PR title format is valid"
           else
             echo "❌ Invalid PR title format"


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-1549)

## Description of changes
Currently dependabot run ends on errors from trying to access our GLAD Parent and Openapi packages. 
We control these and do not expect Dependabot to update them in our repo, so tell it not to bother trying to find the latest version of them for now

https://github.com/ministryofjustice/payforlegalaid/actions/runs/30270661159/job/89992115948
<img width="850" height="373" alt="image" src="https://github.com/user-attachments/assets/6ceaa049-44f7-4ca8-9b8f-66be09d2e820" />

## Evidence
Can't run dependabot without merging :( 

## Checklist
- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
  - Type must be one of: 
    - feat
    - fix
    - docs
    - chore
    - refactor
    - test
    - ci
    - build
    - perf
- [ ] New tests are included if this a new feature
- [ ] Tests and linter checks are passing locally
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history